### PR TITLE
Release v0.2.0

### DIFF
--- a/.github/workflows/test_core.yml
+++ b/.github/workflows/test_core.yml
@@ -2,9 +2,9 @@ name: Rust CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "master" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test_core.yml
+++ b/.github/workflows/test_core.yml
@@ -1,0 +1,30 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-ci-cache"
+
+      - name: Run tests
+        run: cargo test --lib --bins --tests --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,25 @@
+[workspace]
+members = ["binder"]
+
 [package]
 name = "vertra"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
+
+[[bin]]
+name = "vertra_bin"
+path = "src/main.rs"
 
 [dependencies]
 winit = "0.29"
-wgpu = "0.19"
+wgpu = "29.0.1"
 pollster = "0.3"
 bytemuck = { version = "1.14", features = ["derive"] }
+wasm-bindgen-futures = "0.4.67"
+web-time = "1.1.0"
+web-sys = "0.3.94"
+wasm-bindgen = "0.2.117"
+serde = { version = "1.0.228", features = ["derive"] }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,6 @@ name = "vertra"
 version = "0.2.0"
 edition = "2024"
 
-[[bin]]
-name = "vertra_bin"
-path = "src/main.rs"
-
 [dependencies]
 winit = "0.29"
 wgpu = "29.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ web-time = "1.1.0"
 web-sys = "0.3.94"
 wasm-bindgen = "0.2.117"
 serde = { version = "1.0.228", features = ["derive"] }
+uuid = { version = "1.23.0", features = ["v4", "js"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/binder/Cargo.toml
+++ b/binder/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "vertra-binder"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+# This tells the binder to look at the folder above it for the engine
+vertra = { path = ".." }
+wasm-bindgen = "0.2"
+# Add this for better error messages in the browser console
+console_error_panic_hook = "0.1"
+serde-wasm-bindgen = "0.6.5"
+serde = { version = "1.0.228", features = ["derive"] }
+js-sys = "0.3.94"

--- a/binder/src/camera.rs
+++ b/binder/src/camera.rs
@@ -22,12 +22,13 @@ export interface JsCameraOptions {
     znear?: number;
     /** Distance to the far clipping plane. */
     zfar?: number;
-    /** Initial left-right (yaw) rotation in radians. */
+    /** Initial left-right (yaw) rotation in degrees. */
     lr_rot?: number;
-    /** Initial up-down (pitch) rotation in radians. */
+    /** Initial up-down (pitch) rotation in degress. */
     ud_rot?: number;
     /** The initial [x, y, z] position of the camera in world space. */
-    position?: [number, number, number];}
+    position?: [number, number, number];
+}
 "#;
 
 #[derive(Deserialize)]

--- a/binder/src/camera.rs
+++ b/binder/src/camera.rs
@@ -1,0 +1,158 @@
+use wasm_bindgen::prelude::*;
+use serde::Deserialize;
+use vertra::camera::Camera as CoreCamera;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "JsCameraOptions")]
+    pub type JsCameraOptions;
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_CAMERA_CONTENT: &'static str = r#"
+/**
+ * Configuration options for initializing a new Camera instance.
+ */
+export interface JsCameraOptions {
+/** The aspect ratio of the viewport (width / height). */
+    aspect?: number;
+    /** Vertical field of view in degrees. */
+    fov?: number;
+    /** Distance to the near clipping plane. */
+    znear?: number;
+    /** Distance to the far clipping plane. */
+    zfar?: number;
+    /** Initial left-right (yaw) rotation in radians. */
+    lr_rot?: number;
+    /** Initial up-down (pitch) rotation in radians. */
+    ud_rot?: number;
+    /** The initial [x, y, z] position of the camera in world space. */
+    position?: [number, number, number];}
+"#;
+
+#[derive(Deserialize)]
+pub struct CameraConstructorOptions {
+    pub aspect: Option<f32>,
+    pub fov: Option<f32>,
+    pub znear: Option<f32>,
+    pub zfar: Option<f32>,
+    pub lr_rot: Option<f32>,
+    pub ud_rot: Option<f32>,
+    pub position: Option<[f32; 3]>,
+}
+
+/// A 3D camera controller for navigating world space.
+/// Manages projection matrices, position, and orientation.
+#[wasm_bindgen]
+pub struct Camera {
+    #[wasm_bindgen(skip)]
+    pub inner: *mut CoreCamera,
+    #[wasm_bindgen(skip)]
+    pub owned: bool,
+}
+
+#[wasm_bindgen]
+impl Camera {
+    /// Creates a new Camera instance.
+    /// @param {JsCameraOptions} options - Initial configuration for the camera.
+    #[wasm_bindgen(constructor)]
+    pub fn new(options: JsCameraOptions) -> Self {
+        let mut camera = Box::new(CoreCamera::new());
+        let val: JsValue = options.into();
+
+        if !val.is_undefined() && !val.is_null() {
+            if let Ok(opts) = serde_wasm_bindgen::from_value::<CameraConstructorOptions>(val) {
+                if let Some(a) = opts.aspect { camera.aspect = a; }
+                if let Some(f) = opts.fov { camera.fov = f; }
+                if let Some(zn) = opts.znear { camera.znear = zn; }
+                if let Some(zf) = opts.zfar { camera.zfar = zf; }
+
+                // Handle rotation
+                if let (Some(lr), Some(ud)) = (opts.lr_rot, opts.ud_rot) {
+                    *camera = camera.with_rotation(lr, ud);
+                }
+
+                // New: Handle position directly in constructor
+                if let Some(pos) = opts.position {
+                    camera.eye = pos;
+                }
+            }
+        }
+
+        Self { inner: Box::into_raw(camera), owned: true }
+    }
+
+    /// Updates the aspect ratio of the camera.
+    /// Typically called when the window or canvas is resized.
+    /// @param {number} aspect - The aspect ratio in decimal.
+    pub fn set_aspect(&mut self, aspect: f32) {
+        unsafe {
+            (*self.inner).aspect = aspect;
+        }
+    }
+
+    /// Rotates the camera based on screen-space movement deltas.
+    /// @param {number} dx - Relative mouse movement on the X axis.
+    /// @param {number} dy - Relative mouse movement on the Y axis.
+    /// @param {boolean} inverted - Whether to invert the vertical look axis.
+    pub fn rotate(&mut self, dx: f32, dy: f32, inverted: bool) {
+        unsafe {
+            (*self.inner).rotate(dx, dy, inverted);
+        }
+    }
+
+    /// Moves the camera in a specific 3D direction.
+    /// @param {Float32Array | number[]} direction - A 3-element array representing the direction vector.
+    /// @param {number} amount - The distance to move.
+    pub fn move_by(&mut self, direction: Vec<f32>, amount: f32) -> Result<(), JsError> {
+        if direction.len() != 3 {
+            return Err(JsError::new("Direction must be an array of 3 numbers"));
+        }
+        unsafe {
+            (*self.inner).move_by(
+                [direction[0], direction[1], direction[2]],
+                amount
+            );
+        }
+        Ok(())
+    }
+
+    /// Processes keyboard input to move the camera.
+    /// Recognizes WASD and Arrow keys.
+    /// @param {string[]} pressed_keys - An array of active key strings (e.g., from KeyboardEvent.code).
+    /// @param {number} speed - Movement units per second.
+    /// @param {number} dt - Delta time since the last frame in seconds.
+    pub fn handle_input_default(&mut self, pressed_keys: Vec<String>, speed: f32, dt: f32) {
+        unsafe {
+            let (f, r) = (*self.inner).get_directions();
+            let mut move_dir = [0.0, 0.0, 0.0];
+
+            for key in pressed_keys {
+                match key.as_ref() {
+                    "KeyW" | "w" | "ArrowUp" => {
+                        move_dir[0] += f[0]; move_dir[1] += f[1]; move_dir[2] += f[2];
+                    }
+                    "KeyS" | "s" | "ArrowDown" => {
+                        move_dir[0] -= f[0]; move_dir[1] -= f[1]; move_dir[2] -= f[2];
+                    }
+                    "KeyD" | "d" | "ArrowRight" => {
+                        move_dir[0] += r[0]; move_dir[1] += r[1]; move_dir[2] += r[2];
+                    }
+                    "KeyA" | "a" | "ArrowLeft" => {
+                        move_dir[0] -= r[0]; move_dir[1] -= r[1]; move_dir[2] -= r[2];
+                    }
+                    _ => {}
+                }
+            }
+            (*self.inner).move_by(move_dir, speed * dt);
+        }
+    }
+}
+
+impl Drop for Camera {
+    fn drop(&mut self) {
+        if self.owned && !self.inner.is_null() {
+            unsafe { let _ = Box::from_raw(self.inner); }
+        }
+    }
+}

--- a/binder/src/geometry.rs
+++ b/binder/src/geometry.rs
@@ -22,7 +22,7 @@ impl Geometry {
     /// @param {number} width - Size along the X-axis.
     /// @param {number} height - Size along the Y-axis.
     /// @param {number} depth - Size along the Z-axis.
-    #[wasm_bindgen]
+    #[wasm_bindgen(js_name = box)]
     pub fn box_geo(width: f32, height: f32, depth: f32) -> Geometry {
         Geometry { inner: CoreGeometry::Box { width, height, depth } }
     }

--- a/binder/src/geometry.rs
+++ b/binder/src/geometry.rs
@@ -1,0 +1,52 @@
+use wasm_bindgen::prelude::*;
+use vertra::geometry::Geometry as CoreGeometry;
+
+/// Represents a 3D mesh definition that can be used to render objects.
+#[wasm_bindgen]
+pub struct Geometry {
+    pub(crate) inner: CoreGeometry,
+}
+
+/// Creates a cube where all sides (width, height, and depth) are equal.
+/// @param {number} size - The length of each side of the cube.
+#[wasm_bindgen]
+impl Geometry {
+    /// Creates a cube where all sides (width, height, and depth) are equal.
+    /// @param {number} size - The length of each side of the cube.
+    #[wasm_bindgen]
+    pub fn cube(size: f32) -> Geometry {
+        Geometry { inner: CoreGeometry::Cube { size } }
+    }
+
+    /// Creates a rectangular box with independent dimensions.
+    /// @param {number} width - Size along the X-axis.
+    /// @param {number} height - Size along the Y-axis.
+    /// @param {number} depth - Size along the Z-axis.
+    #[wasm_bindgen]
+    pub fn box_geo(width: f32, height: f32, depth: f32) -> Geometry {
+        Geometry { inner: CoreGeometry::Box { width, height, depth } }
+    }
+
+    /// Creates a flat, square surface on the XZ plane.
+    /// @param {number} size - The side length of the square plane.
+    #[wasm_bindgen]
+    pub fn plane(size: f32) -> Geometry {
+        Geometry { inner: CoreGeometry::Plane { size } }
+    }
+
+    /// Creates a spherical mesh (usually a UV sphere or Ico-sphere depending on implementation).
+    /// @param {number} radius - The distance from the center to the surface.
+    /// @param {number} subdivisions - Controls the smoothness of the sphere. Higher values create more triangles.
+    #[wasm_bindgen]
+    pub fn sphere(radius: f32, subdivisions: usize) -> Geometry {
+        Geometry { inner: CoreGeometry::Sphere { radius, subdivisions } }
+    }
+
+    /// Creates a four-sided pyramid with a square base.
+    /// @param {number} base_size - The side length of the square base.
+    /// @param {number} height - The vertical distance from the base to the apex.
+    #[wasm_bindgen]
+    pub fn pyramid(base_size: f32, height: f32) -> Geometry {
+        Geometry { inner: CoreGeometry::Pyramid { base_size, height } }
+    }
+}

--- a/binder/src/lib.rs
+++ b/binder/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod camera;
+pub mod window;
+mod objects;
+mod geometry;
+mod world;
+mod transform;
+mod scene;

--- a/binder/src/objects.rs
+++ b/binder/src/objects.rs
@@ -1,7 +1,35 @@
 use wasm_bindgen::prelude::*;
-use vertra::objects::{Object as CoreObject};
+use vertra::objects::{Object as CoreObject, ObjectConstructor};
 use crate::geometry::Geometry;
 use crate::transform::Transform;
+use serde::Deserialize;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "JsObjectOptions")]
+    pub type JsObjectOptions;
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_OBJECT_CONTENT: &'static str = r#"
+/**
+ * Configuration options for initializing a new VertraObject.
+ */
+export interface JsObjectOptions {
+    /** * A unique string identifier. If provided, this will be used for World lookups.
+     * If omitted, a random UUID will be generated automatically.
+     */
+    str_id?: string;
+    /** The initial color of the object [r, g, b, a]. */
+    color?: [number, number, number, number];
+}
+"#;
+
+#[derive(Deserialize, Default)]
+struct InternalObjectOptions {
+    str_id: Option<String>,
+    color: Option<[f32; 4]>,
+}
 
 /// Represents a node in the 3D scene graph.
 /// Objects hold a name, a transform (position/rotation/scale), and optional geometry/color data.
@@ -15,20 +43,34 @@ pub struct Object {
 
 #[wasm_bindgen(js_name = VertraObject)]
 impl Object {
-    /// Creates a new scene object with a unique name.
-    /// @param {string} name - The identifier for this object.
+    /// Creates a new scene object.
+    /// @param {string} name - The display name.
+    /// @param {JsObjectOptions} [options] - Initial configuration (str_id, color, etc).
     #[wasm_bindgen(constructor)]
-    pub fn new(name: String) -> Self {
-        let obj = Box::new(CoreObject {
+    pub fn new(name: String, options: Option<JsValue>) -> Self {
+        let opts: InternalObjectOptions = options
+            .and_then(|val| {
+                if val.is_undefined() || val.is_null() {
+                    None
+                } else {
+                    serde_wasm_bindgen::from_value(val).ok()
+                }
+            })
+            .unwrap_or_default();
+        
+        let core_obj = CoreObject::new(ObjectConstructor {
             name,
-            ..Default::default()
+            color: opts.color,
+            str_id: opts.str_id,
+            transform: None,
+            geometry: None,
         });
+
         Self {
-            inner: Box::into_raw(obj),
+            inner: Box::into_raw(Box::new(core_obj)),
             owned: true,
         }
     }
-
     /// Sets the name of the object.
     #[wasm_bindgen(setter)]
     pub fn set_name(&mut self, name: String) {
@@ -83,6 +125,13 @@ impl Object {
         unsafe {
             (*self.inner).parent
         }
+    }
+
+    /// Returns the unique string identifier for this object.
+    /// This is assigned at creation and cannot be changed.
+    #[wasm_bindgen(getter)]
+    pub fn str_id(&self) -> String {
+        unsafe { (*self.inner).str_id.clone() }
     }
 
     /// Returns the number of direct children attached to this object.

--- a/binder/src/objects.rs
+++ b/binder/src/objects.rs
@@ -57,7 +57,7 @@ impl Object {
                 }
             })
             .unwrap_or_default();
-        
+
         let core_obj = CoreObject::new(ObjectConstructor {
             name,
             color: opts.color,
@@ -84,11 +84,14 @@ impl Object {
     }
 
     /// Updates the object's spatial properties (position, rotation, scale).
+    /// This mutates the underlying core object referenced by `inner`.
+    /// For objects returned from `World::get_object`, that updates the World-backed object;
+    /// for JS-owned objects created via `new`, it updates the boxed standalone template object.
     /// @param {Transform} transform - The new transform state.
     #[wasm_bindgen(setter)]
     pub fn set_transform(&mut self, transform: &Transform) {
         unsafe {
-            // This updates the memory DIRECTLY inside the HashMap
+            // Mutate the underlying core object in place; this may be World-backed or JS-owned
             (*self.inner).transform = transform.inner.clone();
         }
     }

--- a/binder/src/objects.rs
+++ b/binder/src/objects.rs
@@ -1,0 +1,105 @@
+use wasm_bindgen::prelude::*;
+use vertra::objects::{Object as CoreObject};
+use crate::geometry::Geometry;
+use crate::transform::Transform;
+
+/// Represents a node in the 3D scene graph.
+/// Objects hold a name, a transform (position/rotation/scale), and optional geometry/color data.
+#[wasm_bindgen(js_name = VertraObject)]
+pub struct Object {
+    #[wasm_bindgen(skip)]
+    pub inner: *mut CoreObject,
+    #[wasm_bindgen(skip)]
+    pub owned: bool,
+}
+
+#[wasm_bindgen(js_name = VertraObject)]
+impl Object {
+    /// Creates a new scene object with a unique name.
+    /// @param {string} name - The identifier for this object.
+    #[wasm_bindgen(constructor)]
+    pub fn new(name: String) -> Self {
+        let obj = Box::new(CoreObject {
+            name,
+            ..Default::default()
+        });
+        Self {
+            inner: Box::into_raw(obj),
+            owned: true,
+        }
+    }
+
+    /// Sets the name of the object.
+    #[wasm_bindgen(setter)]
+    pub fn set_name(&mut self, name: String) {
+        unsafe {(*self.inner).name = name}
+    }
+
+    /// Gets the current name of the object.
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> String {
+        unsafe { (*self.inner).name.clone() }
+    }
+
+    /// Updates the object's spatial properties (position, rotation, scale).
+    /// @param {Transform} transform - The new transform state.
+    #[wasm_bindgen(setter)]
+    pub fn set_transform(&mut self, transform: &Transform) {
+        unsafe {
+            // This updates the memory DIRECTLY inside the HashMap
+            (*self.inner).transform = transform.inner.clone();
+        }
+    }
+
+    /// Returns a copy of the object's current transform.
+    #[wasm_bindgen(getter)]
+    pub fn transform(&self) -> Transform {
+        unsafe {
+            Transform { inner: (*self.inner).transform.clone() }
+        }
+    }
+
+    /// Sets the RGBA color of the object.
+    /// @param {Float32Array | number[]} color - An array of 4 numbers [r, g, b, a] ranging from 0.0 to 1.0.
+    pub fn set_color(&mut self, color: Vec<f32>) {
+        unsafe {
+            if color.len() == 4 {
+                (*self.inner).color = [color[0], color[1], color[2], color[3]];
+            }
+        }
+    }
+
+    /// Attaches a mesh geometry to this object for rendering.
+    /// @param {Geometry} geometry - The geometry to be applied.
+    pub fn set_geometry(&mut self, geometry: &Geometry) {
+        unsafe {
+            (*self.inner).geometry = Some(geometry.inner.clone());
+        }
+    }
+
+    /// Returns the ID of the parent object, if one exists.
+    #[wasm_bindgen(getter)]
+    pub fn parent(&self) -> Option<usize> {
+        unsafe {
+            (*self.inner).parent
+        }
+    }
+
+    /// Returns the number of direct children attached to this object.
+    #[wasm_bindgen(getter)]
+    pub fn children_count(&self) -> usize {
+        unsafe {
+            (*self.inner).children.len()
+        }
+    }
+}
+
+impl Drop for Object {
+    fn drop(&mut self) {
+        if self.owned && !self.inner.is_null() {
+            unsafe {
+                let _ = Box::from_raw(self.inner);
+            }
+        }
+    }
+}

--- a/binder/src/scene.rs
+++ b/binder/src/scene.rs
@@ -1,0 +1,51 @@
+use wasm_bindgen::prelude::*;
+use crate::objects::Object;
+use crate::world::World;
+use vertra::scene::{Scene as CoreScene};
+use crate::camera::Camera;
+
+/// The root container for a 3D environment.
+/// Manages the object lifecycle, scene hierarchy, and the active viewport camera.
+#[wasm_bindgen]
+pub struct Scene {
+    #[wasm_bindgen(skip)]
+    pub inner: *mut CoreScene,
+}
+
+#[wasm_bindgen]
+impl Scene {
+    /// Spawns a new object into the scene.
+    ///
+    /// @param {VertraObject} object - The object template to add to the scene.
+    /// @param {number | null} [parent_id] - The ID of the parent object. If null, it is added to the scene root.
+    /// @returns {number} The unique ID assigned to this object instance within the scene.
+    pub fn spawn(&mut self, object: &Object, parent_id: Option<usize>) -> usize {
+        // We clone the inner object to move it into the world
+        unsafe {
+            (*self.inner).spawn((*object.inner).clone(), parent_id)
+        }
+    }
+
+    /// Accesses the underlying World data structure.
+    /// Use this to query entities or batch-update transforms.
+    #[wasm_bindgen(getter)]
+    pub fn world(&self) -> World {
+        unsafe {
+            World {
+                inner: &mut (*self.inner).world as *mut vertra::world::World
+            }
+        }
+    }
+
+    /// Returns the primary camera used to render this scene.
+    /// Note: This camera is owned by the Scene; do not attempt to manually destroy it.
+    #[wasm_bindgen(getter)]
+    pub fn camera(&self) -> Camera {
+        unsafe {
+            Camera {
+                inner: &mut (*self.inner).camera as *mut vertra::camera::Camera,
+                owned: false,
+            }
+        }
+    }
+}

--- a/binder/src/scene.rs
+++ b/binder/src/scene.rs
@@ -1,7 +1,8 @@
 use wasm_bindgen::prelude::*;
+use vertra::scene::{Scene as CoreScene};
+use std::io::Cursor;
 use crate::objects::Object;
 use crate::world::World;
-use vertra::scene::{Scene as CoreScene};
 use crate::camera::Camera;
 
 /// The root container for a 3D environment.
@@ -46,6 +47,31 @@ impl Scene {
                 inner: &mut (*self.inner).camera as *mut vertra::camera::Camera,
                 owned: false,
             }
+        }
+    }
+
+    /// Exports the scene as a VTR binary buffer.
+    /// @returns {Uint8Array} The binary data of the scene.
+    pub fn save_vtr(&self) -> Result<Vec<u8>, JsValue> {
+        unsafe {
+            let mut buf = Vec::new();
+            vertra::vtr::write(&mut buf, &(*self.inner).camera, &(*self.inner).world)
+                .map_err(|e| JsValue::from_str(&e.to_string()))?;
+            Ok(buf)
+        }
+    }
+
+    /// Loads a VTR scene from a binary buffer.
+    /// @param {Uint8Array} data - The VTR binary data.
+    pub fn load_vtr(&mut self, data: &[u8]) -> Result<(), JsValue> {
+        unsafe {
+            let mut cur = Cursor::new(data);
+            let scene_data = vertra::vtr::read(&mut cur)
+                .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+            (*self.inner).camera = scene_data.camera;
+            (*self.inner).world = scene_data.world;
+            Ok(())
         }
     }
 }

--- a/binder/src/transform.rs
+++ b/binder/src/transform.rs
@@ -10,7 +10,7 @@ extern "C" {
 
 #[wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = r#"
-export interface JsTransformOptions {
+export interface TransformOptions {
     position?: [number, number, number];
     rotation?: [number, number, number];
     scale?: [number, number, number];
@@ -75,7 +75,7 @@ impl Transform {
         self.inner.rotation.to_vec()
     }
 
-    /// Sets the rotation. Expects a 3-element array of Euler angles (radians).
+    /// Sets the rotation. Expects a 3-element array of Euler angles (degrees).
     #[wasm_bindgen(setter)]
     pub fn set_rotation(&mut self, val: Vec<f32>) {
         if val.len() == 3 {

--- a/binder/src/transform.rs
+++ b/binder/src/transform.rs
@@ -1,0 +1,108 @@
+use wasm_bindgen::prelude::*;
+use serde::{Deserialize, Serialize};
+use vertra::transform::{Transform as CoreTransform};
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "TransformOptions")]
+    pub type JsTransformOptions;
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_APPEND_CONTENT: &'static str = r#"
+export interface JsTransformOptions {
+    position?: [number, number, number];
+    rotation?: [number, number, number];
+    scale?: [number, number, number];
+}
+"#;
+
+/// Manages spatial data including position, rotation, and scale.
+/// Used to calculate local-to-world matrices and hierarchy transformations.
+#[wasm_bindgen]
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Transform {
+    #[wasm_bindgen(skip)]
+    pub inner: CoreTransform,
+}
+
+// We use a regular Rust struct for the options and let Serde handle the JS object
+#[derive(Deserialize)]
+pub struct TransformConstructorOptions {
+    pub position: Option<[f32; 3]>,
+    pub rotation: Option<[f32; 3]>,
+    pub scale: Option<[f32; 3]>,
+}
+
+#[wasm_bindgen]
+impl Transform {
+    /// Creates a new Transform.
+    /// @param {ITransformOptions} options - Initial spatial values.
+    #[wasm_bindgen(constructor)]
+    pub fn new(options: JsTransformOptions) -> Self {
+        let mut inner = CoreTransform::default();
+        let val: JsValue = options.into();
+
+        // If the user passed an object, try to parse it
+        if !val.is_undefined() && !val.is_null() {
+            if let Ok(opts) = serde_wasm_bindgen::from_value::<TransformConstructorOptions>(val) {
+                if let Some(pos) = opts.position { inner.position = pos; }
+                if let Some(rot) = opts.rotation { inner.rotation = rot; }
+                if let Some(scl) = opts.scale { inner.scale = scl; }
+            }
+        }
+
+        Self { inner }
+    }
+
+    /// Returns the [x, y, z] position.
+    #[wasm_bindgen(getter)]
+    pub fn position(&self) -> Vec<f32> {
+        self.inner.position.to_vec()
+    }
+
+    /// Sets the position. Expects a 3-element array.
+    #[wasm_bindgen(setter)]
+    pub fn set_position(&mut self, val: Vec<f32>) {
+        if val.len() == 3 {
+            self.inner.position = [val[0], val[1], val[2]];
+        }
+    }
+
+    /// Returns the [x, y, z] Euler rotation.
+    #[wasm_bindgen(getter)]
+    pub fn rotation(&self) -> Vec<f32> {
+        self.inner.rotation.to_vec()
+    }
+
+    /// Sets the rotation. Expects a 3-element array of Euler angles (radians).
+    #[wasm_bindgen(setter)]
+    pub fn set_rotation(&mut self, val: Vec<f32>) {
+        if val.len() == 3 {
+            self.inner.rotation = [val[0], val[1], val[2]];
+        }
+    }
+
+    /// Returns the [x, y, z] scale factors.
+    #[wasm_bindgen(getter)]
+    pub fn scale(&self) -> Vec<f32> {
+        self.inner.scale.to_vec()
+    }
+
+    /// Sets the scale. Expects a 3-element array.
+    #[wasm_bindgen(setter)]
+    pub fn set_scale(&mut self, val: Vec<f32>) {
+        if val.len() == 3 {
+            self.inner.scale = [val[0], val[1], val[2]];
+        }
+    }
+
+    /// Combines this transform with a child transform, returning a new local-to-world result.
+    /// Useful for calculating the absolute position of a nested object.
+    /// @param {Transform} child - The local transform to apply to this parent transform.
+    pub fn combine_wasm(&self, child: &Transform) -> Transform {
+        // Since CoreTransform implements Clone, we can just use the inner value
+        let combined = self.inner.combine(&child.inner);
+        Self { inner: combined }
+    }
+}

--- a/binder/src/window.rs
+++ b/binder/src/window.rs
@@ -64,11 +64,11 @@ impl WebWindow {
         }
     }
 
-    /// Sets the function to call once before the first frame.
+    /// Sets the function to call every frame for logic updates.
     /// Callback signature: (state, scene, frameContext) => void
     pub fn on_update(&mut self, f: Function) { self.on_update = Some(f); }
 
-    /// Sets the function to call every frame for logic updates.
+    /// Sets the function to call once before the first frame.
     /// Callback signature: (state, scene, frameContext) => void
     pub fn on_startup(&mut self, f: Function) { self.on_startup = Some(f); }
 

--- a/binder/src/window.rs
+++ b/binder/src/window.rs
@@ -1,0 +1,190 @@
+use wasm_bindgen::prelude::*;
+use vertra::window::Window;
+use vertra::event::{DeviceEvent, ElementState, PhysicalKey};
+use crate::scene::Scene;
+use vertra::event::{Event, WindowEvent};
+use js_sys::Function;
+use serde::Serialize;
+use crate::camera::Camera;
+
+#[wasm_bindgen(start)]
+pub fn main_js() {
+    // This ensures any Rust panic is printed to the JS console
+    console_error_panic_hook::set_once();
+}
+
+/// Contains information about the current frame.
+#[wasm_bindgen]
+pub struct FrameContext {
+    /// Time elapsed since the last frame in seconds.
+    pub dt: f32,
+}
+
+/// Represents an input event sent from the engine to the JavaScript handler.
+/// Serialized as a tagged union in JS: { type: "keydown", data: { ... } }
+#[derive(Serialize)]
+#[serde(tag = "type", content = "data")]
+pub enum WebEvent {
+    #[serde(rename = "keydown")]
+    KeyDown { code: String, repeat: bool },
+    #[serde(rename = "keyup")]
+    KeyUp { code: String },
+    #[serde(rename = "mousemove")]
+    MouseMove { x: f64, y: f64 },
+    #[serde(rename = "mousemotion")]
+    MouseMotion { dx: f64, dy: f64 },
+}
+
+/// The main application controller that manages the canvas and the render loop.
+#[wasm_bindgen]
+pub struct WebWindow {
+    state: JsValue,
+    camera: Camera,
+    on_update: Option<Function>,
+    on_draw_request: Option<Function>,
+    on_startup: Option<Function>,
+    with_event_handler: Option<Function>,
+}
+
+#[wasm_bindgen]
+impl WebWindow {
+    /// Creates a new WebWindow.
+    /// @param {Camera} camera - The initial camera for the scene.
+    /// @param {any} [state] - Initial state object passed to every callback.
+    #[wasm_bindgen(constructor)]
+    pub fn new(camera: Camera, state: Option<JsValue>) -> Self {
+        console_error_panic_hook::set_once();
+        Self {
+            state: state.unwrap_or(JsValue::NULL),
+            camera,
+            on_update: None,
+            on_draw_request: None,
+            on_startup: None,
+            with_event_handler: None,
+        }
+    }
+
+    /// Sets the function to call once before the first frame.
+    /// Callback signature: (state, scene, frameContext) => void
+    pub fn on_update(&mut self, f: Function) { self.on_update = Some(f); }
+
+    /// Sets the function to call every frame for logic updates.
+    /// Callback signature: (state, scene, frameContext) => void
+    pub fn on_startup(&mut self, f: Function) { self.on_startup = Some(f); }
+
+    /// Sets the function to call when the scene needs to be re-rendered.
+    /// Callback signature: (state, scene, frameContext) => void
+    pub fn on_draw_request(&mut self, f: Function) { self.on_draw_request = Some(f); }
+
+    /// Registers a handler for input events (keyboard/mouse).
+    /// Callback signature: (state, scene, event) => void
+    /// The event is an object: { type: string, data: any }
+    pub fn with_event_handler(&mut self, f: Function) { self.with_event_handler = Some(f); }
+
+    /// Initializes the engine and starts the RequestAnimationFrame loop.
+    /// @param {string} canvas_id - The ID of the HTMLCanvasElement to target.
+    pub fn start(mut self, canvas_id: String) {
+        // Initialize the engine window with JsValue as the state type S
+        let camera_val = unsafe {
+            if self.camera.owned {
+                self.camera.owned = false;
+                *Box::from_raw(self.camera.inner)
+            } else {
+                core::ptr::read(self.camera.inner)
+            }
+        };
+
+        let mut engine_window = Window::new(self.state)
+            .with_title("Vertra Web")
+            .with_canvas_id(canvas_id)
+            .with_camera(camera_val);
+
+        // We can't move a reference into an owned Wasm struct.
+        unsafe fn wrap_scene(scene: &mut vertra::scene::Scene) -> Scene {
+            Scene { inner: scene as *mut vertra::scene::Scene }
+        }
+
+        if let Some(f) = self.on_startup {
+            engine_window = engine_window.on_startup(move |state, scene, _ctx| {
+                let frame_ctx = FrameContext { dt: _ctx.dt };
+                let _ = f.call3(
+                    &JsValue::UNDEFINED,
+                    state,
+                    &JsValue::from(unsafe { wrap_scene(scene) }),
+                    &JsValue::from(frame_ctx)
+                );
+            });
+        }
+
+        if let Some(f) = self.on_update {
+            engine_window = engine_window.on_update(move |state, scene, _ctx| {
+                let frame_ctx = FrameContext { dt: _ctx.dt };
+                let _ = f.call3(
+                    &JsValue::UNDEFINED,
+                    state,
+                    &JsValue::from(unsafe { wrap_scene(scene) }),
+                    &JsValue::from(frame_ctx)
+                );
+            });
+        }
+
+        if let Some(f) = self.on_draw_request {
+            engine_window = engine_window.on_draw_request(move |state, scene, _ctx| {
+                let frame_ctx = FrameContext { dt: _ctx.dt };
+                let _ = f.call3(
+                    &JsValue::UNDEFINED,
+                    state,
+                    &JsValue::from(unsafe { wrap_scene(scene) }),
+                    &JsValue::from(frame_ctx)
+                );
+            });
+        }
+
+        if let Some(f) = self.with_event_handler {
+            engine_window = engine_window.with_event_handler(move |state, scene, event, _elwt| {
+                let web_event = match event {
+                    // Handle Keyboard Input
+                    Event::WindowEvent { event: WindowEvent::KeyboardInput { event: key_event, .. }, .. } => {
+                        if let PhysicalKey::Code(code) = key_event.physical_key {
+                            let code_str = format!("{:?}", code); // e.g., "KeyW"
+                            match key_event.state {
+                                ElementState::Pressed => Some(WebEvent::KeyDown {
+                                    code: code_str,
+                                    repeat: key_event.repeat
+                                }),
+                                ElementState::Released => Some(WebEvent::KeyUp {
+                                    code: code_str
+                                }),
+                            }
+                        } else { None }
+                    }
+
+                    // Handle Raw Mouse Motion (for camera rotation)
+                    Event::DeviceEvent { event: DeviceEvent::MouseMotion { delta }, .. } => {
+                        Some(WebEvent::MouseMotion { dx: delta.0, dy: delta.1 })
+                    }
+
+                    // Handle Cursor Position
+                    Event::WindowEvent { event: WindowEvent::CursorMoved { position, .. }, .. } => {
+                        Some(WebEvent::MouseMove { x: position.x, y: position.y })
+                    }
+
+                    _ => None,
+                };
+
+                // If we have an event, serialize it to a JsValue and send it to JS
+                if let Some(e) = web_event {
+                    if let Ok(js_event_obj) = serde_wasm_bindgen::to_value(&e) {
+                        let _ = f.call3(
+                            &JsValue::UNDEFINED,
+                            state,
+                            &JsValue::from(unsafe { wrap_scene(scene) }),
+                            &js_event_obj,
+                        );
+                    }
+                }
+            });
+        }
+        engine_window.create();
+    }
+}

--- a/binder/src/world.rs
+++ b/binder/src/world.rs
@@ -45,6 +45,17 @@ impl World {
         }
     }
 
+    /// Resolves a string identifier (`str_id`) to its unique integer ID.
+    ///
+    /// @param {string} str_id - The string handle (e.g., "player", "sun").
+    /// @returns {number | undefined} The integer ID, or undefined if not found.
+    /// @note This involves a hashmap lookup. Cache the resulting number in JS for hot loops.
+    pub fn get_id(&self, str_id: &str) -> Option<usize> {
+        unsafe {
+            (*self.inner).get_id(str_id)
+        }
+    }
+
     /// Returns a list of IDs for objects that have no parent (the root nodes).
     /// @returns {Uint32Array | number[]} An array of object IDs.
     pub fn get_roots(&self) -> Vec<usize> {

--- a/binder/src/world.rs
+++ b/binder/src/world.rs
@@ -1,0 +1,55 @@
+use wasm_bindgen::prelude::*;
+use crate::objects::Object;
+use vertra::world::{World as CoreWorld};
+
+/// The entity management system and scene hierarchy container.
+/// Handles the creation, destruction, and retrieval of scene objects.
+#[wasm_bindgen]
+pub struct World {
+    #[wasm_bindgen(skip)]
+    pub inner: *mut CoreWorld,
+}
+
+#[wasm_bindgen]
+impl World {
+    /// Spawns an object. parent_id can be passed as undefined/null from JS.
+    pub fn spawn_object(&mut self, object: &Object, parent_id: Option<usize>) -> usize {
+        unsafe {
+            (*self.inner).spawn_object((*object.inner).clone(), parent_id)
+        }
+    }
+
+    /// Creates a new object instance in the world.
+    ///
+    /// @param {VertraObject} object - The template object to clone into the world.
+    /// @param {number | null} [parent_id] - The ID of an existing object to act as the parent.
+    /// If null, the object is added to the scene root.
+    /// @returns {number} The unique ID assigned to the new instance.
+    pub fn delete(&mut self, id: usize) {
+        unsafe {
+            (*self.inner).delete(id);
+        }
+    }
+
+    /// Retrieves an existing object from the world by its ID.
+    ///
+    /// @param {number} id - The unique ID of the object.
+    /// @returns {VertraObject | undefined} A reference to the object, or undefined if the ID is invalid.
+    /// @note This returns a reference owned by the World. Do not manually destroy this object in JS.
+    pub fn get_object(&self, id: usize) -> Option<Object> {
+        unsafe {
+            (*self.inner).objects.get_mut(&id).map(|obj| Object {
+                inner: obj as *mut vertra::objects::Object,
+                owned: false,
+            })
+        }
+    }
+
+    /// Returns a list of IDs for objects that have no parent (the root nodes).
+    /// @returns {Uint32Array | number[]} An array of object IDs.
+    pub fn get_roots(&self) -> Vec<usize> {
+        unsafe {
+            (*self.inner).roots.clone()
+        }
+    }
+}

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -4,7 +4,7 @@ use crate::math::Matrix4;
 use crate::constants::camera;
 use crate::window::FrameContext;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Camera {
     pub eye: [f32; 3],    // Position of the camera
     pub target: [f32; 3], // Where the camera is looking

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,4 +1,5 @@
 pub use winit::{
-    event::{Event, WindowEvent},
+    keyboard::PhysicalKey,
+    event::{Event, WindowEvent, DeviceEvent, ElementState},
     event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
 };

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,9 +1,11 @@
 use crate::mesh::{MeshData, Vertex};
 use crate::transform::Transform;
+use serde::{Serialize, Deserialize};
 
 #[derive(Debug, Copy, Clone)]
 pub struct GeometryId(pub usize);
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum Geometry {
     Cube { size: f32 },
     Box { width: f32, height: f32, depth: f32 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,4 @@ pub mod objects;
 
 #[cfg(test)]
 mod tests;
+pub mod vtr;

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,6 +1,8 @@
 use crate::geometry::Geometry;
 use crate::transform::Transform;
+use serde::{Deserialize, Serialize};
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Object {
     pub name: String,
     pub transform: Transform,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,6 +1,7 @@
 use crate::geometry::Geometry;
 use crate::transform::Transform;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Object {
@@ -10,10 +11,12 @@ pub struct Object {
     pub color: [f32; 4],
     pub children: Vec<usize>,
     pub parent: Option<usize>,
+    pub str_id: String,
 }
 
 pub struct ObjectConstructor {
     pub name: String,
+    pub str_id: Option<String>,
     pub transform: Option<Transform>,
     pub geometry: Option<Geometry>,
     pub color: Option<[f32; 4]>,
@@ -26,6 +29,7 @@ impl Default for Object {
             transform: None,
             geometry: None,
             color: None,
+            str_id: Uuid::new_v4().to_string().into(),
         })
     }
 }
@@ -36,13 +40,21 @@ impl Object {
             name: config.name,
             transform: config.transform.unwrap_or_default(),
             geometry: config.geometry,
+            // Since we use UUID to generate
+            str_id: config.str_id.unwrap_or_default(),
             color: config.color.unwrap_or([1.0, 1.0, 1.0, 1.0]),
             children: Vec::new(),
             parent: None,
         }
     }
 
-    pub fn from_geometry(name: &str, geometry: Geometry, transform: Transform, color: [f32; 4]) -> Self {
+    pub fn from_geometry(
+        name: &str,
+        str_id: Option<String>,
+        geometry: Geometry,
+        transform: Transform,
+        color: [f32; 4]
+    ) -> Self {
         Self {
             name: name.to_string(),
             transform,
@@ -50,6 +62,7 @@ impl Object {
             color,
             children: Vec::new(),
             parent: None,
+            str_id: str_id.unwrap_or_else(|| Uuid::new_v4().to_string()).into(),
         }
     }
 }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -41,7 +41,7 @@ impl Object {
             transform: config.transform.unwrap_or_default(),
             geometry: config.geometry,
             // Since we use UUID to generate
-            str_id: config.str_id.unwrap_or_default(),
+            str_id: config.str_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
             color: config.color.unwrap_or([1.0, 1.0, 1.0, 1.0]),
             children: Vec::new(),
             parent: None,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -194,8 +194,7 @@ impl Pipeline {
         {
             let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-
-                    view: &view,// Expected: &wgpu::api::texture_view::TextureView
+                    view: &view,
                     resolve_target: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use wgpu::{Device, Queue, Surface};
+use wgpu::{Device, PipelineCompilationOptions, Queue, Surface};
 use wgpu::util::DeviceExt;
 use crate::camera::Camera;
 use crate::mesh::{BakedMesh, Vertex};
@@ -28,22 +28,20 @@ pub struct Pipeline {
 }
 
 impl Pipeline {
-    pub fn initialize(window: Arc<winit::window::Window>) -> Self {
+    pub async fn initialize(window: Arc<winit::window::Window>) -> Self {
         let instance = wgpu::Instance::default();
         let surface = instance.create_surface(Arc::clone(&window)).unwrap();
-        let adapter = pollster::block_on(instance.request_adapter(
+        let adapter = instance.request_adapter(
             &wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::HighPerformance,
                 compatible_surface: Some(&surface),
                 force_fallback_adapter: false,
             },
-        )).unwrap();
+        ).await.expect("Failed to find an appropriate adapter");
 
-        let (device, queue) = pollster::block_on(adapter.request_device(
+        let (device, queue) = adapter.request_device(
             &wgpu::DeviceDescriptor::default(),
-            None,
-        )).unwrap();
-
+        ).await.expect("Failed to create device");
 
         let size = window.inner_size();
         let surface_config = surface.get_default_config(&adapter, size.width, size.height).unwrap();
@@ -84,8 +82,8 @@ impl Pipeline {
 
         let render_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("Render Pipeline Layout"),
-            bind_group_layouts: &[&camera_bind_group_layout],
-            push_constant_ranges: &[],
+            bind_group_layouts: &[Some(&camera_bind_group_layout)],
+            immediate_size: 0
         });
 
         let depth_texture = device.create_texture(&wgpu::TextureDescriptor {
@@ -108,9 +106,12 @@ impl Pipeline {
         let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: Some("Render Pipeline"),
             layout: Some(&render_pipeline_layout),
+            cache: None,
+            multiview_mask: None,
             vertex: wgpu::VertexState {
                 module: &shader,
-                entry_point: "vs_main",
+                entry_point: Some("vs_main"),
+                compilation_options: PipelineCompilationOptions::default(),
                 buffers: &[
                     wgpu::VertexBufferLayout {
                         array_stride: size_of::<Vertex>() as wgpu::BufferAddress,
@@ -134,7 +135,8 @@ impl Pipeline {
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
-                entry_point: "fs_main",
+                entry_point: Some("fs_main"),
+                compilation_options: PipelineCompilationOptions::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: surface_config.format,
                     blend: Some(wgpu::BlendState::REPLACE),
@@ -147,14 +149,13 @@ impl Pipeline {
             },
             depth_stencil: Some(wgpu::DepthStencilState {
                 format: wgpu::TextureFormat::Depth32Float,
-                depth_write_enabled: true,
+                depth_write_enabled: Some(true),
                 // "Less" means: Draw the new pixel only if its distance is LESS than the existing one
-                depth_compare: wgpu::CompareFunction::Less,
+                depth_compare: Some(wgpu::CompareFunction::Less),
                 stencil: wgpu::StencilState::default(),
                 bias: wgpu::DepthBiasState::default(),
             }),
             multisample: wgpu::MultisampleState::default(),
-            multiview: None,
         });
 
         Self {
@@ -172,19 +173,19 @@ impl Pipeline {
 
     pub fn render_baked_mesh(&mut self, mesh: &BakedMesh, camera: &Camera) {
         let frame = match self.surface.get_current_texture() {
-            Ok(frame) => frame,
-            Err(wgpu::SurfaceError::Outdated) => {
-                self.surface.configure(&self.device, &self.surface_config);
+            wgpu::CurrentSurfaceTexture::Success(frame) => frame,
+            wgpu::CurrentSurfaceTexture::Suboptimal(frame) => {
+                frame
+            }
+            wgpu::CurrentSurfaceTexture::Timeout => return,
+            wgpu::CurrentSurfaceTexture::Outdated | wgpu::CurrentSurfaceTexture::Lost => {
                 return;
             }
-            Err(e) => {
-                eprintln!("Dropped frame due to error: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Occluded => return,
+            wgpu::CurrentSurfaceTexture::Validation => panic!("Surface validation error"),
         };
         let view = frame.texture.create_view(&wgpu::TextureViewDescriptor::default());
 
-        // Update Global Camera Uniform
         let camera_matrix = camera.build_view_projection_matrix();
         self.queue.write_buffer(&self.camera_buffer, 0, bytemuck::cast_slice(&[camera_matrix.data]));
 
@@ -193,12 +194,14 @@ impl Pipeline {
         {
             let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: &view,
+
+                    view: &view,// Expected: &wgpu::api::texture_view::TextureView
                     resolve_target: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
                         store: wgpu::StoreOp::Store,
                     },
+                    depth_slice: None,
                 })],
                 depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
                     view: &self.depth_view,
@@ -216,13 +219,13 @@ impl Pipeline {
             // We only need Bind Group 0 (Camera).
             // All position/color data is already "baked" into the vertex buffer.
             rpass.set_bind_group(0, &self.camera_bind_group, &[]);
-
-            rpass.set_vertex_buffer(0, mesh.vertex_buffer.slice(..));
-            rpass.set_index_buffer(mesh.index_buffer.slice(..), wgpu::IndexFormat::Uint32);
-
-            // DRAW CALL: This draws the entire world in one shot
-            // (might change in the future)
-            rpass.draw_indexed(0..mesh.index_count, 0, 0..1);
+            if mesh.index_count > 0 {
+                rpass.set_vertex_buffer(0, mesh.vertex_buffer.slice(..));
+                rpass.set_index_buffer(mesh.index_buffer.slice(..), wgpu::IndexFormat::Uint32);
+                // DRAW CALL: This draws the entire world in one shot
+                // (might change in the future)
+                rpass.draw_indexed(0..mesh.index_count, 0, 0..1);
+            }
         }
 
         self.queue.submit(std::iter::once(encoder.finish()));

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -4,6 +4,7 @@ use crate::pipeline::Pipeline;
 use crate::world::World;
 use crate::objects::Object;
 use crate::transform::Transform;
+use crate::vtr::{self, VtrError};
 
 pub struct Scene {
     pub pipeline: Pipeline,
@@ -32,5 +33,30 @@ impl Scene {
         let world_baked = mesh_data.bake(&self.pipeline);
 
         self.pipeline.render_baked_mesh(&world_baked, &self.camera);
+    }
+
+    /// Serialize the current camera and world to a `.vtr` binary file.
+    ///
+    /// Creates or truncates the file at `path`.
+    ///
+    /// # Errors
+    /// Returns a [`VtrError`] on I/O failure or serialization problems.
+    pub fn save_vtr_file(&self, path: &std::path::Path) -> Result<(), VtrError> {
+        vtr::write_to_file(path, &self.camera, &self.world)
+    }
+
+    /// Replace the current camera and world with the contents of a `.vtr` file.
+    ///
+    /// The GPU pipeline is **not** affected — only the logical scene state
+    /// (camera, objects, hierarchy) is replaced.
+    ///
+    /// # Errors
+    /// Returns a [`VtrError`] on I/O failure, bad magic bytes, unsupported
+    /// format version, or any other parse error.
+    pub fn load_vtr_file(&mut self, path: &std::path::Path) -> Result<(), VtrError> {
+        let data = vtr::read_from_file(path)?;
+        self.camera = data.camera;
+        self.world = data.world;
+        Ok(())
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,1 +1,3 @@
 mod test_timer;
+mod test_vtr;
+

--- a/src/tests/test_vtr.rs
+++ b/src/tests/test_vtr.rs
@@ -1,0 +1,1001 @@
+/// Tests for the VTR binary scene format (vtr.rs).
+///
+/// All tests operate on in-memory buffers (`Vec<u8>` / `std::io::Cursor`) so
+/// no filesystem I/O is required and the suite runs fully offline.
+///
+/// Coverage:
+///   - round-trip: empty scene, single object, full hierarchy
+///   - every Geometry variant
+///   - camera field fidelity
+///   - root ordering preservation
+///   - next_id continuity after load (no ID collision on spawn)
+///   - deterministic / idempotent output
+///   - header-only reads (`read_header`)
+///   - `VtrHeader::engine_version_string`
+///   - error path: bad magic bytes
+///   - error path: unsupported format version
+///   - error path: unknown geometry tag
+///   - error path: truncated data (unexpected EOF)
+///   - UTF-8 object names (including multibyte characters)
+///   - object with maximum-length name (u16::MAX bytes)
+///   - deeply nested hierarchy (3 levels)
+///   - multiple root objects, order preserved
+///   - object with no geometry but non-default transform and color
+///   - object deleted after load doesn't affect sibling IDs
+
+use std::io::Cursor;
+use crate::camera::Camera;
+use crate::geometry::Geometry;
+use crate::objects::{Object, ObjectConstructor};
+use crate::transform::Transform;
+use crate::vtr::{
+    self, ENGINE_VERSION_MAJOR, ENGINE_VERSION_MINOR, ENGINE_VERSION_PATCH, FORMAT_VERSION, MAGIC,
+};
+use crate::world::World;
+
+// helpers
+/// Build a default Camera for tests.
+fn test_camera() -> Camera {
+    Camera::new()
+}
+
+/// Build a Camera with non-default values so we can verify all fields survive.
+fn custom_camera() -> Camera {
+    Camera {
+        eye: [1.0, 2.0, 3.0],
+        target: [4.0, 5.0, 6.0],
+        up: [0.0, 1.0, 0.0],
+        aspect: 16.0 / 9.0,
+        fov: 60.0,
+        znear: 0.01,
+        zfar: 500.0,
+        lr_rot: 45.0,
+        ud_rot: -15.0,
+    }
+}
+
+/// Serialize (camera, world) → Vec<u8> via the in-memory write path.
+fn serialize(camera: &Camera, world: &World) -> Vec<u8> {
+    let mut buf = Vec::new();
+    vtr::write(&mut buf, camera, world).expect("write failed");
+    buf
+}
+
+/// Deserialize a byte slice back into SceneData.
+fn deserialize(bytes: &[u8]) -> vtr::SceneData {
+    let mut cur = Cursor::new(bytes);
+    vtr::read(&mut cur).expect("read failed")
+}
+
+/// Round-trip helper: write then read, returning SceneData.
+fn roundtrip(camera: &Camera, world: &World) -> vtr::SceneData {
+    let bytes = serialize(camera, world);
+    deserialize(&bytes)
+}
+
+/// Assert two cameras are field-for-field equal.
+fn assert_cameras_eq(a: &Camera, b: &Camera) {
+    assert_eq!(a.eye, b.eye, "eye mismatch");
+    assert_eq!(a.target, b.target, "target mismatch");
+    assert_eq!(a.up, b.up, "up mismatch");
+    assert_eq!(a.aspect, b.aspect, "aspect mismatch");
+    assert_eq!(a.fov, b.fov, "fov mismatch");
+    assert_eq!(a.znear, b.znear, "znear mismatch");
+    assert_eq!(a.zfar, b.zfar, "zfar mismatch");
+    assert_eq!(a.lr_rot, b.lr_rot, "lr_rot mismatch");
+    assert_eq!(a.ud_rot, b.ud_rot, "ud_rot mismatch");
+}
+
+/// Assert two objects are field-for-field equal.
+fn assert_objects_eq(a: &Object, b: &Object) {
+    assert_eq!(a.name, b.name, "name mismatch");
+    assert_eq!(a.transform, b.transform, "transform mismatch");
+    assert_eq!(a.geometry, b.geometry, "geometry mismatch");
+    assert_eq!(a.color, b.color, "color mismatch");
+    assert_eq!(a.parent, b.parent, "parent mismatch");
+    // Sort children before comparing - insertion order may differ on reload.
+    let mut ca = a.children.clone();
+    let mut cb = b.children.clone();
+    ca.sort_unstable();
+    cb.sort_unstable();
+    assert_eq!(ca, cb, "children mismatch");
+}
+
+// header tests
+#[test]
+fn header_magic_and_version() {
+    let world = World::new();
+    let bytes = serialize(&test_camera(), &world);
+
+    // First 4 bytes must be the magic constant.
+    assert_eq!(&bytes[0..4], &MAGIC, "magic bytes wrong");
+
+    // Bytes [4..6] are format_version in little-endian.
+    let fv = u16::from_le_bytes([bytes[4], bytes[5]]);
+    assert_eq!(fv, FORMAT_VERSION);
+}
+
+#[test]
+fn header_engine_version_fields() {
+    let world = World::new();
+    let bytes = serialize(&test_camera(), &world);
+
+    let major = u16::from_le_bytes([bytes[6], bytes[7]]);
+    let minor = u16::from_le_bytes([bytes[8], bytes[9]]);
+    let patch = u16::from_le_bytes([bytes[10], bytes[11]]);
+
+    assert_eq!(major, ENGINE_VERSION_MAJOR);
+    assert_eq!(minor, ENGINE_VERSION_MINOR);
+    assert_eq!(patch, ENGINE_VERSION_PATCH);
+}
+
+#[test]
+fn header_flags_reserved_zero() {
+    let world = World::new();
+    let bytes = serialize(&test_camera(), &world);
+
+    let flags = u32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]);
+    assert_eq!(flags, 0, "reserved flags must be zero");
+}
+
+#[test]
+fn read_header_only() {
+    let mut world = World::new();
+    world.spawn_object(Object::default(), None);
+    world.spawn_object(Object::default(), None);
+
+    let bytes = serialize(&test_camera(), &world);
+    let mut cur = Cursor::new(&bytes[..]);
+    let hdr = vtr::read_header(&mut cur).expect("read_header failed");
+
+    assert_eq!(hdr.format_version, FORMAT_VERSION);
+    assert_eq!(hdr.engine_major, ENGINE_VERSION_MAJOR);
+    assert_eq!(hdr.engine_minor, ENGINE_VERSION_MINOR);
+    assert_eq!(hdr.engine_patch, ENGINE_VERSION_PATCH);
+    assert_eq!(hdr.object_count, 2);
+}
+
+#[test]
+fn header_engine_version_string() {
+    let hdr = vtr::VtrHeader {
+        format_version: FORMAT_VERSION,
+        engine_major: 1,
+        engine_minor: 2,
+        engine_patch: 3,
+        object_count: 0,
+    };
+    assert_eq!(hdr.engine_version_string(), "1.2.3");
+}
+
+// empty scene
+#[test]
+fn empty_scene_roundtrip() {
+    let camera = custom_camera();
+    let world = World::new();
+    let data = roundtrip(&camera, &world);
+
+    assert_cameras_eq(&camera, &data.camera);
+    assert!(data.world.objects.is_empty());
+    assert!(data.world.roots.is_empty());
+}
+
+#[test]
+fn empty_scene_minimum_size() {
+    // header(20) + camera(60) + roots_count(4) = 84 bytes minimum
+    let bytes = serialize(&test_camera(), &World::new());
+    assert_eq!(bytes.len(), 84, "minimum file size should be 84 bytes");
+}
+
+// camera round-trip
+#[test]
+fn camera_all_fields_preserved() {
+    let camera = custom_camera();
+    let data = roundtrip(&camera, &World::new());
+    assert_cameras_eq(&camera, &data.camera);
+}
+
+#[test]
+fn camera_negative_values() {
+    let camera = Camera {
+        eye: [-100.5, -0.001, -999.9],
+        target: [-1.0, -2.0, -3.0],
+        up: [0.0, -1.0, 0.0],
+        aspect: 0.5625,
+        fov: 120.0,
+        znear: 0.001,
+        zfar: 10_000.0,
+        lr_rot: -180.0,
+        ud_rot: -89.0,
+    };
+    let data = roundtrip(&camera, &World::new());
+    assert_cameras_eq(&camera, &data.camera);
+}
+
+// single object
+#[test]
+fn single_object_no_geometry() {
+    let mut world = World::new();
+    let id = world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: "Bare Box".to_string(),
+            transform: Some(Transform {
+                position: [1.0, 2.0, 3.0],
+                rotation: [10.0, 20.0, 30.0],
+                scale: [2.0, 0.5, 1.0],
+            }),
+            geometry: None,
+            color: Some([0.1, 0.2, 0.3, 0.9]),
+            str_id: None
+        }),
+        None,
+    );
+
+    let data = roundtrip(&test_camera(), &world);
+    let obj = data.world.objects.get(&id).expect("object missing after roundtrip");
+
+    assert_objects_eq(obj, world.objects.get(&id).unwrap());
+    assert_eq!(data.world.roots, vec![id]);
+}
+
+#[test]
+fn single_object_default() {
+    let mut world = World::new();
+    let id = world.spawn_object(Object::default(), None);
+
+    let data = roundtrip(&test_camera(), &world);
+    let original = world.objects.get(&id).unwrap();
+    let loaded = data.world.objects.get(&id).unwrap();
+
+    assert_objects_eq(loaded, original);
+}
+
+// geometry variants
+fn roundtrip_geometry(geom: Geometry) -> Option<Geometry> {
+    let mut world = World::new();
+    world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: "geo test".to_string(),
+            transform: None,
+            geometry: Some(geom),
+            color: None,
+            str_id: None
+        }),
+        None,
+    );
+    let data = roundtrip(&test_camera(), &world);
+    data.world.objects.into_values().next().unwrap().geometry
+}
+
+#[test]
+fn geometry_none_roundtrip() {
+    let mut world = World::new();
+    let id = world.spawn_object(Object::default(), None); // geometry = None by default
+    let data = roundtrip(&test_camera(), &world);
+    assert!(data.world.objects[&id].geometry.is_none());
+}
+
+#[test]
+fn geometry_cube_roundtrip() {
+    let g = Geometry::Cube { size: 3.14 };
+    assert_eq!(roundtrip_geometry(g.clone()), Some(g));
+}
+
+#[test]
+fn geometry_box_roundtrip() {
+    let g = Geometry::Box { width: 1.0, height: 2.5, depth: 0.75 };
+    assert_eq!(roundtrip_geometry(g.clone()), Some(g));
+}
+
+#[test]
+fn geometry_plane_roundtrip() {
+    let g = Geometry::Plane { size: 10.0 };
+    assert_eq!(roundtrip_geometry(g.clone()), Some(g));
+}
+
+#[test]
+fn geometry_pyramid_roundtrip() {
+    let g = Geometry::Pyramid { base_size: 4.0, height: 6.0 };
+    assert_eq!(roundtrip_geometry(g.clone()), Some(g));
+}
+
+#[test]
+fn geometry_capsule_roundtrip() {
+    let g = Geometry::Capsule { radius: 0.5, height: 2.0, subdivisions: 16 };
+    assert_eq!(roundtrip_geometry(g.clone()), Some(g));
+}
+
+#[test]
+fn geometry_sphere_roundtrip() {
+    let g = Geometry::Sphere { radius: 1.0, subdivisions: 32 };
+    assert_eq!(roundtrip_geometry(g.clone()), Some(g));
+}
+
+#[test]
+fn geometry_capsule_large_subdivisions() {
+    let g = Geometry::Capsule { radius: 1.0, height: 5.0, subdivisions: 256 };
+    assert_eq!(roundtrip_geometry(g.clone()), Some(g));
+}
+
+// hierarchy tests
+#[test]
+fn parent_child_roundtrip() {
+    let mut world = World::new();
+    let parent_id = world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: "Parent".to_string(),
+            transform: None,
+            geometry: Some(Geometry::Cube { size: 1.0 }),
+            color: Some([1.0, 0.0, 0.0, 1.0]),
+            str_id: None
+        }),
+        None,
+    );
+    let child_id = world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: "Child".to_string(),
+            transform: Some(Transform::from_position(5.0, 0.0, 0.0)),
+            geometry: Some(Geometry::Sphere { radius: 0.5, subdivisions: 8 }),
+            color: Some([0.0, 1.0, 0.0, 1.0]),
+            str_id: None
+        }),
+        Some(parent_id),
+    );
+
+    let data = roundtrip(&test_camera(), &world);
+
+    // Hierarchy links preserved.
+    let loaded_parent = &data.world.objects[&parent_id];
+    let loaded_child = &data.world.objects[&child_id];
+
+    assert!(loaded_parent.children.contains(&child_id), "child not linked to parent");
+    assert_eq!(loaded_child.parent, Some(parent_id), "child's parent pointer wrong");
+
+    // Only the true root appears in roots.
+    assert_eq!(data.world.roots, vec![parent_id]);
+
+    assert_objects_eq(loaded_parent, &world.objects[&parent_id]);
+    assert_objects_eq(loaded_child, &world.objects[&child_id]);
+}
+
+#[test]
+fn deep_three_level_hierarchy() {
+    let mut world = World::new();
+    let sun_id = world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: "Sun".to_string(),
+            transform: None,
+            geometry: Some(Geometry::Sphere { radius: 2.0, subdivisions: 32 }),
+            color: Some([1.0, 0.9, 0.2, 1.0]),
+            str_id: None
+        }),
+        None,
+    );
+    let planet_id = world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: "Planet".to_string(),
+            transform: Some(Transform::from_position(6.0, 0.0, 0.0)),
+            geometry: Some(Geometry::Sphere { radius: 0.8, subdivisions: 24 }),
+            color: Some([0.2, 0.5, 1.0, 1.0]),
+            str_id: None
+        }),
+        Some(sun_id),
+    );
+    let moon_id = world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: "Moon".to_string(),
+            transform: Some(Transform::from_position(1.5, 0.0, 0.0)),
+            geometry: Some(Geometry::Sphere { radius: 0.3, subdivisions: 16 }),
+            color: Some([0.7, 0.7, 0.7, 1.0]),
+            str_id: None
+        }),
+        Some(planet_id),
+    );
+
+    let data = roundtrip(&test_camera(), &world);
+
+    assert_eq!(data.world.roots, vec![sun_id], "only sun is root");
+    assert_eq!(data.world.objects[&sun_id].children, vec![planet_id]);
+    assert_eq!(data.world.objects[&planet_id].children, vec![moon_id]);
+    assert_eq!(data.world.objects[&moon_id].children, vec![]);
+    assert_eq!(data.world.objects[&moon_id].parent, Some(planet_id));
+}
+
+#[test]
+fn multiple_roots_order_preserved() {
+    let mut world = World::new();
+    // Spawn 5 roots - the serializer must restore them in the same order.
+    let ids: Vec<usize> = (0..5)
+        .map(|i| {
+            world.spawn_object(
+                Object::new(ObjectConstructor {
+                    name: format!("Root{i}"),
+                    transform: None,
+                    geometry: None,
+                    color: None,
+                    str_id: None
+                }),
+                None,
+            )
+        })
+        .collect();
+
+    let data = roundtrip(&test_camera(), &world);
+    assert_eq!(data.world.roots, ids, "root insertion order not preserved");
+}
+
+#[test]
+fn multiple_roots_with_children() {
+    let mut world = World::new();
+    let r1 = world.spawn_object(Object::default(), None);
+    let r2 = world.spawn_object(Object::default(), None);
+    let c1 = world.spawn_object(Object::default(), Some(r1));
+    let c2 = world.spawn_object(Object::default(), Some(r2));
+    let c3 = world.spawn_object(Object::default(), Some(r1)); // second child of r1
+
+    let data = roundtrip(&test_camera(), &world);
+
+    assert_eq!(data.world.roots, vec![r1, r2]);
+    assert!(data.world.objects[&r1].children.contains(&c1));
+    assert!(data.world.objects[&r1].children.contains(&c3));
+    assert!(data.world.objects[&r2].children.contains(&c2));
+    assert_eq!(data.world.objects[&c1].parent, Some(r1));
+    assert_eq!(data.world.objects[&c2].parent, Some(r2));
+    assert_eq!(data.world.objects[&c3].parent, Some(r1));
+}
+
+// ID continuity after load
+#[test]
+fn next_id_after_load_does_not_collide() {
+    let mut world = World::new();
+    let existing_ids: Vec<usize> = (0..3).map(|_| world.spawn_object(Object::default(), None)).collect();
+
+    let data = roundtrip(&test_camera(), &world);
+    let mut loaded_world = data.world;
+
+    // Spawn a new object after loading - its ID must not collide.
+    let new_id = loaded_world.spawn_object(Object::default(), None);
+    assert!(
+        !existing_ids.contains(&new_id),
+        "new ID {new_id} collides with a loaded object ID"
+    );
+    assert_eq!(
+        loaded_world.objects.len(),
+        4,
+        "should have 3 loaded + 1 new object"
+    );
+}
+
+#[test]
+fn spawn_after_load_links_correctly() {
+    let mut world = World::new();
+    let root_id = world.spawn_object(Object::default(), None);
+
+    let data = roundtrip(&test_camera(), &world);
+    let mut loaded = data.world;
+
+    let child_id = loaded.spawn_object(Object::default(), Some(root_id));
+
+    assert!(loaded.objects[&root_id].children.contains(&child_id));
+    assert_eq!(loaded.objects[&child_id].parent, Some(root_id));
+}
+
+// object name tests
+#[test]
+fn empty_name_roundtrip() {
+    let mut world = World::new();
+    let id = world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: String::new(),
+            transform: None,
+            geometry: None,
+            color: None,
+            str_id: None
+        }),
+        None,
+    );
+    let data = roundtrip(&test_camera(), &world);
+    assert_eq!(data.world.objects[&id].name, "");
+}
+
+#[test]
+fn unicode_name_roundtrip() {
+    let name = "太陽 ☀ Soleil 🌍".to_string();
+    let mut world = World::new();
+    let id = world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: name.clone(),
+            transform: None,
+            geometry: None,
+            color: None,
+            str_id: None
+        }),
+        None,
+    );
+    let data = roundtrip(&test_camera(), &world);
+    assert_eq!(data.world.objects[&id].name, name);
+}
+
+#[test]
+fn long_name_roundtrip() {
+    // 300 ASCII chars - well under u16::MAX but exercises the length prefix.
+    let name = "x".repeat(300);
+    let mut world = World::new();
+    let id = world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: name.clone(),
+            transform: None,
+            geometry: None,
+            color: None,
+            str_id: None
+        }),
+        None,
+    );
+    let data = roundtrip(&test_camera(), &world);
+    assert_eq!(data.world.objects[&id].name, name);
+}
+
+// transform & color fidelity
+#[test]
+fn transform_all_fields() {
+    let t = Transform {
+        position: [-12.34, 56.78, -0.001],
+        rotation: [180.0, -90.0, 45.0],
+        scale: [0.1, 100.0, 3.14159],
+    };
+    let mut world = World::new();
+    let id = world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: "t".to_string(),
+            transform: Some(t.clone()),
+            geometry: None,
+            color: None,
+            str_id: None
+        }),
+        None,
+    );
+    let data = roundtrip(&test_camera(), &world);
+    assert_eq!(data.world.objects[&id].transform, t);
+}
+
+#[test]
+fn color_transparent_black() {
+    let color = [0.0_f32, 0.0, 0.0, 0.0];
+    let mut world = World::new();
+    let id = world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: "c".to_string(),
+            transform: None,
+            geometry: None,
+            color: Some(color),
+            str_id: None
+        }),
+        None,
+    );
+    let data = roundtrip(&test_camera(), &world);
+    assert_eq!(data.world.objects[&id].color, color);
+}
+
+#[test]
+fn color_hdr_values() {
+    // HDR colors can exceed 1.0 - verify no clamping.
+    let color = [2.5_f32, 0.0, 10.0, 1.0];
+    let mut world = World::new();
+    let id = world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: "hdr".to_string(),
+            transform: None,
+            geometry: None,
+            color: Some(color),
+            str_id: None
+        }),
+        None,
+    );
+    let data = roundtrip(&test_camera(), &world);
+    assert_eq!(data.world.objects[&id].color, color);
+}
+
+// determinism
+#[test]
+fn deterministic_output() {
+    // Serializing the same world twice must produce identical bytes.
+    let mut world = World::new();
+    let r = world.spawn_object(Object::default(), None);
+    world.spawn_object(Object::default(), Some(r));
+    world.spawn_object(Object::default(), Some(r));
+
+    let bytes1 = serialize(&test_camera(), &world);
+    let bytes2 = serialize(&test_camera(), &world);
+    assert_eq!(bytes1, bytes2, "serialization must be deterministic");
+}
+
+#[test]
+fn idempotent_roundtrip() {
+    // Serialize -> deserialize -> serialize again: the bytes must be identical.
+    let mut world = World::new();
+    let r = world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: "Sphere".to_string(),
+            transform: Some(Transform::from_position(1.0, 2.0, 3.0)),
+            geometry: Some(Geometry::Sphere { radius: 1.0, subdivisions: 16 }),
+            color: Some([0.8, 0.2, 0.4, 1.0]),
+            str_id: None
+        }),
+        None,
+    );
+    world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: "Child".to_string(),
+            transform: None,
+            geometry: Some(Geometry::Cube { size: 0.5 }),
+            color: None,
+            str_id: None
+        }),
+        Some(r),
+    );
+
+    let camera = custom_camera();
+    let bytes1 = serialize(&camera, &world);
+    let data = deserialize(&bytes1);
+    let bytes2 = serialize(&data.camera, &data.world);
+
+    assert_eq!(bytes1, bytes2, "output must be idempotent");
+}
+
+// large scene
+#[test]
+fn many_objects_roundtrip() {
+    const N: usize = 200;
+    let mut world = World::new();
+    let root = world.spawn_object(Object::default(), None);
+    for i in 0..N {
+        world.spawn_object(
+            Object::new(ObjectConstructor {
+                name: format!("obj_{i}"),
+                transform: Some(Transform::from_position(i as f32, 0.0, 0.0)),
+                geometry: Some(Geometry::Cube { size: 1.0 }),
+                color: Some([i as f32 / N as f32, 0.5, 1.0, 1.0]),
+                str_id: None
+            }),
+            Some(root),
+        );
+    }
+
+    let data = roundtrip(&test_camera(), &world);
+    assert_eq!(data.world.objects.len(), N + 1, "all objects present");
+    assert_eq!(data.world.objects[&root].children.len(), N);
+}
+
+// error paths
+#[test]
+fn error_bad_magic() {
+    let mut bytes = serialize(&test_camera(), &World::new());
+    bytes[0] = 0xFF; // corrupt the first magic byte
+    let mut cur = Cursor::new(&bytes[..]);
+    let result = vtr::read(&mut cur);
+    assert!(
+        matches!(result, Err(vtr::VtrError::InvalidMagic)),
+        "expected InvalidMagic, got {result:?}"
+    );
+}
+
+#[test]
+fn error_wrong_magic_all_zeros() {
+    let bytes = vec![0u8; 20];
+    let mut cur = Cursor::new(&bytes[..]);
+    assert!(matches!(vtr::read(&mut cur), Err(vtr::VtrError::InvalidMagic)));
+}
+
+#[test]
+fn error_unsupported_version() {
+    let mut bytes = serialize(&test_camera(), &World::new());
+    // Overwrite format_version field (bytes 4-5) with an unsupported value.
+    let bad_ver: u16 = 999;
+    let le = bad_ver.to_le_bytes();
+    bytes[4] = le[0];
+    bytes[5] = le[1];
+
+    let mut cur = Cursor::new(&bytes[..]);
+    let result = vtr::read(&mut cur);
+    assert!(
+        matches!(result, Err(vtr::VtrError::UnsupportedVersion { found: 999 })),
+        "expected UnsupportedVersion(999), got {result:?}"
+    );
+}
+
+#[test]
+fn error_unknown_geometry_tag() {
+    let mut world = World::new();
+    let fixed_sid = "test-uuid-0000-1111-2222-333344445555".to_string(); // 36 chars
+
+    world.spawn_object(Object {
+        name: "TAG_TEST".to_string(),
+        str_id: fixed_sid.clone(),
+        ..Object::default()
+    }, None);
+
+    let mut bytes = serialize(&test_camera(), &world);
+
+    let name_bytes = b"TAG_TEST";
+    let name_pos = bytes.windows(name_bytes.len())
+        .position(|window| window == name_bytes)
+        .expect("Could not find object name in binary data");
+
+    // offset = name_start + name_len
+    //        + transform(36)
+    //        + color(16)
+    //        + str_id_len_prefix(2)
+    //        + str_id_content(36)
+    let tag_offset = name_pos + name_bytes.len() + 36 + 16 + 2 + fixed_sid.len();
+
+    // Verify we are within bounds
+    assert!(tag_offset < bytes.len(), "Calculated offset is out of bounds!");
+
+    bytes[tag_offset] = 0xAB;
+
+    let mut cur = Cursor::new(&bytes[..]);
+    let result = vtr::read(&mut cur);
+
+    assert!(
+        matches!(result, Err(vtr::VtrError::UnknownGeometryTag(0xAB))),
+        "Expected UnknownGeometryTag(0xAB), but the parser didn't hit the corrupted byte. Offset might still be wrong."
+    );
+}
+
+#[test]
+fn error_truncated_header() {
+    // Only 10 bytes - not enough for the full header.
+    let bytes = vec![0x56, 0x54, 0x52, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00];
+    let mut cur = Cursor::new(&bytes[..]);
+    let result = vtr::read(&mut cur);
+    assert!(
+        matches!(result, Err(vtr::VtrError::Io(_))),
+        "expected Io error for truncated header, got {result:?}"
+    );
+}
+
+#[test]
+fn error_truncated_camera_block() {
+    let bytes = serialize(&test_camera(), &World::new());
+    // Truncate in the middle of the camera block.
+    let truncated = &bytes[..30];
+    let mut cur = Cursor::new(truncated);
+    assert!(
+        matches!(vtr::read(&mut cur), Err(vtr::VtrError::Io(_))),
+        "expected Io error for truncated camera"
+    );
+}
+
+#[test]
+fn error_truncated_object_data() {
+    let mut world = World::new();
+    world.spawn_object(Object::default(), None);
+    let bytes = serialize(&test_camera(), &world);
+    // Truncate inside the first object's data.
+    let truncated = &bytes[..bytes.len() - 10];
+    let mut cur = Cursor::new(truncated);
+    assert!(
+        matches!(vtr::read(&mut cur), Err(vtr::VtrError::Io(_))),
+        "expected Io error for truncated object"
+    );
+}
+
+// error display
+#[test]
+fn error_display_invalid_magic() {
+    let e = vtr::VtrError::InvalidMagic;
+    assert!(e.to_string().contains("magic"), "InvalidMagic display: {e}");
+}
+
+#[test]
+fn error_display_unsupported_version() {
+    let e = vtr::VtrError::UnsupportedVersion { found: 42 };
+    let s = e.to_string();
+    assert!(s.contains("42"), "should mention found version: {s}");
+}
+
+#[test]
+fn error_display_unknown_tag() {
+    let e = vtr::VtrError::UnknownGeometryTag(0x0F);
+    let s = e.to_string();
+    assert!(s.contains("0x0f") || s.contains("0x0F") || s.contains("15"), "{s}");
+}
+
+// delete-after-load
+#[test]
+fn delete_after_load_does_not_affect_sibling() {
+    let mut world = World::new();
+    let r = world.spawn_object(Object::default(), None);
+    let c1 = world.spawn_object(Object::default(), Some(r));
+    let c2 = world.spawn_object(Object::default(), Some(r));
+
+    let data = roundtrip(&test_camera(), &world);
+    let mut w = data.world;
+
+    w.delete(c1);
+
+    assert!(w.objects.contains_key(&c2), "sibling c2 must still exist after deleting c1");
+    assert!(!w.objects[&r].children.contains(&c1), "c1 must be unlinked from parent");
+    assert!(w.objects[&r].children.contains(&c2), "c2 must still be linked to parent");
+}
+
+// full solar system scene (integration)
+#[test]
+fn solar_system_full_roundtrip() {
+    let mut world = World::new();
+
+    let sun = world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: "Sun".to_string(),
+            transform: Some(Transform::from_position(0.0, 0.0, 0.0)),
+            geometry: Some(Geometry::Sphere { radius: 2.0, subdivisions: 32 }),
+            color: Some([1.0, 0.9, 0.2, 1.0]),
+            str_id: None
+        }),
+        None,
+    );
+    let planet = world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: "Planet".to_string(),
+            transform: Some(Transform::from_position(6.0, 0.0, 0.0)),
+            geometry: Some(Geometry::Sphere { radius: 0.8, subdivisions: 24 }),
+            color: Some([0.2, 0.5, 1.0, 1.0]),
+            str_id: None
+        }),
+        Some(sun),
+    );
+    let moon = world.spawn_object(
+        Object::new(ObjectConstructor {
+            name: "Moon".to_string(),
+            transform: Some(Transform::from_position(1.5, 0.0, 0.0)),
+            geometry: Some(Geometry::Sphere { radius: 0.3, subdivisions: 16 }),
+            color: Some([0.7, 0.7, 0.7, 1.0]),
+            str_id: None
+        }),
+        Some(planet),
+    );
+    // An asteroid belt: 10 asteroids orbiting the sun.
+    let belt_ids: Vec<usize> = (0..10)
+        .map(|i| {
+            world.spawn_object(
+                Object::new(ObjectConstructor {
+                    name: format!("Asteroid {i}"),
+                    transform: Some(Transform::from_position(4.0 + i as f32 * 0.2, 0.0, 0.0)),
+                    geometry: Some(Geometry::Sphere { radius: 0.05, subdivisions: 4 }),
+                    color: Some([0.6, 0.5, 0.4, 1.0]),
+                    str_id: None
+                }),
+                Some(sun),
+            )
+        })
+        .collect();
+
+    let camera = Camera::new()
+        .with_position([0.0, 8.0, -12.0])
+        .with_rotation(90.0, -30.0);
+
+    let data = roundtrip(&camera, &world);
+
+    // Structural checks.
+    assert_eq!(data.world.roots, vec![sun]);
+    assert_eq!(data.world.objects.len(), 13); // sun + planet + moon + 10 asteroids
+
+    // Sun has planet + 10 asteroids as children.
+    let sun_children = &data.world.objects[&sun].children;
+    assert!(sun_children.contains(&planet));
+    for &aid in &belt_ids {
+        assert!(sun_children.contains(&aid), "asteroid {aid} should be a sun child");
+    }
+
+    // Planet -> Moon.
+    assert_eq!(data.world.objects[&planet].children, vec![moon]);
+    assert_eq!(data.world.objects[&moon].parent, Some(planet));
+
+    // Camera preserved.
+    assert_cameras_eq(&camera, &data.camera);
+
+    // All names intact.
+    assert_eq!(data.world.objects[&sun].name, "Sun");
+    assert_eq!(data.world.objects[&planet].name, "Planet");
+    assert_eq!(data.world.objects[&moon].name, "Moon");
+}
+
+// --- str_id Specific Tests ---
+
+#[test]
+fn str_id_roundtrip_preservation() {
+    let mut world = World::new();
+    let sid = "unique_handle_123".to_string();
+
+    let id = world.spawn_object(
+        Object {
+            name: "Handle Test".to_string(),
+            str_id: sid.clone(),
+            ..Object::default()
+        },
+        None,
+    );
+
+    let data = roundtrip(&test_camera(), &world);
+    let loaded_obj = data.world.objects.get(&id).expect("Object missing");
+
+    // Verify the string survived the binary serialization
+    assert_eq!(loaded_obj.str_id, sid, "str_id mismatch after roundtrip");
+}
+
+#[test]
+fn str_id_cache_rebuild_on_load() {
+    let mut world = World::new();
+    let sid = "player_spawn_point".to_string();
+
+    world.spawn_object(
+            Object {
+                name: "Spawn".to_string(),
+                str_id: sid.clone(),
+                ..Object::default()
+            },
+        None,
+    );
+
+    let data = roundtrip(&test_camera(), &world);
+
+    // Verify the name_handles HashMap was rebuilt correctly from the loaded objects
+    let lookup_id = data.world.get_id(&sid);
+    assert!(lookup_id.is_some(), "name_handles cache was not rebuilt on load");
+
+    let obj = data.world.objects.get(&lookup_id.unwrap()).unwrap();
+    assert_eq!(obj.name, "Spawn");
+}
+
+#[test]
+fn str_id_cleanup_on_delete() {
+    let mut world = World::new();
+    let sid = "temporary_object".to_string();
+
+    let id = world.spawn_object(
+        Object {
+            name: "Temp".to_string(),
+            str_id: sid.clone(),
+            ..Object::default()
+        },
+        None,
+    );
+
+    // Ensure it exists first
+    assert!(!world.get_id(&sid).is_some());
+
+    // Delete the object
+    world.delete(id);
+
+    // Verify both the object AND the handle are gone
+    assert!(!world.objects.contains_key(&id), "Object still exists in map");
+    assert!(world.get_id(&sid).is_none(), "str_id handle was not cleaned up after delete");
+}
+
+#[test]
+fn str_id_empty_by_default() {
+    let mut world = World::new();
+    let id = world.spawn_object(Object::default(), None);
+
+    let data = roundtrip(&test_camera(), &world);
+    let loaded_obj = &data.world.objects[&id];
+
+    assert!(!loaded_obj.str_id.is_empty(), "str_id should not be empty if UUID fallback is active");
+}
+
+#[test]
+fn str_id_unicode_handles() {
+    let unicode_id = "核心_引擎_01".to_string();
+    let mut world = World::new();
+
+    world.spawn_object(
+        Object {
+            name: "Unicode Test".to_string(),
+            str_id: unicode_id.clone(),
+            ..Object::default()
+        },
+        None,
+    );
+
+    let data = roundtrip(&test_camera(), &world);
+    assert_eq!(data.world.get_id(&unicode_id).is_some(), true);
+}

--- a/src/tests/test_vtr.rs
+++ b/src/tests/test_vtr.rs
@@ -17,7 +17,7 @@
 ///   - error path: unknown geometry tag
 ///   - error path: truncated data (unexpected EOF)
 ///   - UTF-8 object names (including multibyte characters)
-///   - object with maximum-length name (u16::MAX bytes)
+///   - object with long names (including a 300-byte name)
 ///   - deeply nested hierarchy (3 levels)
 ///   - multiple root objects, order preserved
 ///   - object with no geometry but non-default transform and color
@@ -961,7 +961,7 @@ fn str_id_cleanup_on_delete() {
     );
 
     // Ensure it exists first
-    assert!(!world.get_id(&sid).is_some());
+    assert!(world.get_id(&sid).is_some());
 
     // Delete the object
     world.delete(id);

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,5 +1,7 @@
 use crate::math::Matrix4;
+use serde::{Deserialize, Serialize};
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Transform {
     pub position: [f32; 3],
     pub rotation: [f32; 3],  // All rotation-related data are measured in degrees

--- a/src/vtr.rs
+++ b/src/vtr.rs
@@ -68,7 +68,7 @@ pub const FORMAT_VERSION: u16 = 1;
 
 /// Engine version embedded in the header for informational purposes.
 pub const ENGINE_VERSION_MAJOR: u16 = 0;
-pub const ENGINE_VERSION_MINOR: u16 = 1;
+pub const ENGINE_VERSION_MINOR: u16 = 2;
 pub const ENGINE_VERSION_PATCH: u16 = 0;
 
 /// Sentinel stored in `parent_id` when an object has no parent.
@@ -339,7 +339,6 @@ pub fn read_header(r: &mut impl Read) -> Result<VtrHeader, VtrError> {
 /// Objects are written in ascending `id` order so the binary output is
 /// deterministic for the same scene regardless of HashMap iteration order.
 pub fn write(w: &mut impl Write, camera: &Camera, world: &World) -> Result<(), VtrError> {
-    // ── Header ──────────────────────────────────────────────────────────────
     w.write_all(&MAGIC)?;
     w_u16(w, FORMAT_VERSION)?;
     w_u16(w, ENGINE_VERSION_MAJOR)?;

--- a/src/vtr.rs
+++ b/src/vtr.rs
@@ -1,0 +1,514 @@
+//! # VTR Binary Scene Format
+//!
+//! A compact, lossless, little-endian binary format for Vertra scene files.
+//!
+//! ## File Layout
+//!
+//! ```text
+//! ┌──────────────────────────────────────────────────────────────┐
+//! │  HEADER  (20 bytes)                                          │
+//! │  [0..4]   magic:          b"VTR\x00"                         │
+//! │  [4..6]   format_version: u16 LE  (= FORMAT_VERSION)         │
+//! │  [6..8]   engine_major:   u16 LE                             │
+//! │  [8..10]  engine_minor:   u16 LE                             │
+//! │  [10..12] engine_patch:   u16 LE                             │
+//! │  [12..16] flags:          u32 LE  (= 0, reserved)            │
+//! │  [16..20] object_count:   u32 LE                             │
+//! ├──────────────────────────────────────────────────────────────┤
+//! │  CAMERA BLOCK  (60 bytes)                                    │
+//! │  eye[3], target[3], up[3]: f32 LE  (36 bytes)                │
+//! │  aspect, fov, znear, zfar, lr_rot, ud_rot: f32 LE (24 bytes) │
+//! ├──────────────────────────────────────────────────────────────┤
+//! │  ROOTS SECTION                                               │
+//! │  roots_count: u32 LE                                         │
+//! │  root_ids:    u32 LE * roots_count                           │
+//! ├──────────────────────────────────────────────────────────────┤
+//! │  OBJECTS SECTION  (object_count entries, ascending id order) │
+//! │  Per object:                                                 │
+//! │    id:             u32 LE                                    │
+//! │    parent_id:      u32 LE  (u32::MAX = no parent)            │
+//! │    name_len:       u16 LE                                    │
+//! │    str_id_len:     u16 LE                                    │
+//! │    str_id:         utf-8 bytes [str_id_len]                  │
+//! │    name:           utf-8 bytes [name_len]                    │
+//! │    position[3]:    f32 LE * 3                                │
+//! │    rotation[3]:    f32 LE * 3                                │
+//! │    scale[3]:       f32 LE * 3                                │
+//! │    color[4]:       f32 LE * 4                                │
+//! │    geometry_tag:   u8                                        │
+//! │      0=None  1=Cube  2=Box  3=Plane                          │
+//! │      4=Pyramid  5=Capsule  6=Sphere                          │
+//! │    geometry_data:  (varies by tag)                           │
+//! │    children_count: u32 LE                                    │
+//! │    children:       u32 LE * children_count                   │
+//! └──────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! Minimum valid file (header + empty camera + no objects): **84 bytes**.
+//! Compare to an equivalent JSON representation which would be several kilobytes
+//! even for trivial scenes.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{self, BufReader, BufWriter, Read, Write};
+use std::path::Path;
+
+use crate::camera::Camera;
+use crate::geometry::Geometry;
+use crate::objects::Object;
+use crate::transform::Transform;
+use crate::world::World;
+
+// Constants
+/// Magic bytes that identify every valid VTR file.
+pub const MAGIC: [u8; 4] = [0x56, 0x54, 0x52, 0x00]; // "VTR\0"
+
+/// Bump this whenever the binary layout changes in a backward-incompatible way.
+pub const FORMAT_VERSION: u16 = 1;
+
+/// Engine version embedded in the header for informational purposes.
+pub const ENGINE_VERSION_MAJOR: u16 = 0;
+pub const ENGINE_VERSION_MINOR: u16 = 1;
+pub const ENGINE_VERSION_PATCH: u16 = 0;
+
+/// Sentinel stored in `parent_id` when an object has no parent.
+const NO_PARENT: u32 = u32::MAX;
+
+// Public types
+
+/// All scene data loaded from (or prepared for) a `.vtr` file.
+#[derive(Debug)]
+pub struct SceneData {
+    pub camera: Camera,
+    pub world: World,
+}
+
+/// Metadata from the file header — readable without parsing the full scene.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VtrHeader {
+    /// Version of the binary layout (must equal [`FORMAT_VERSION`] to load).
+    pub format_version: u16,
+    /// Engine major version that wrote this file.
+    pub engine_major: u16,
+    /// Engine minor version that wrote this file.
+    pub engine_minor: u16,
+    /// Engine patch version that wrote this file.
+    pub engine_patch: u16,
+    /// Number of objects in the scene.
+    pub object_count: u32,
+}
+
+impl VtrHeader {
+    /// Human-readable engine version string, e.g. `"0.1.0"`.
+    pub fn engine_version_string(&self) -> String {
+        format!("{}.{}.{}", self.engine_major, self.engine_minor, self.engine_patch)
+    }
+}
+
+/// Errors that can occur when reading or writing `.vtr` files.
+#[derive(Debug)]
+pub enum VtrError {
+    Io(io::Error),
+    /// The first four bytes do not match `b"VTR\0"`.
+    InvalidMagic,
+    /// The `format_version` field is not recognised by this implementation.
+    UnsupportedVersion { found: u16 },
+    /// An object's name field contained invalid UTF-8.
+    InvalidUtf8(std::string::FromUtf8Error),
+    /// An unknown `geometry_tag` byte was encountered.
+    UnknownGeometryTag(u8),
+}
+
+impl std::fmt::Display for VtrError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VtrError::Io(e) => write!(f, "I/O error: {e}"),
+            VtrError::InvalidMagic => {
+                write!(f, "Not a valid VTR file (magic bytes mismatch)")
+            }
+            VtrError::UnsupportedVersion { found } => {
+                write!(
+                    f,
+                    "Unsupported VTR format version {found} \
+                     (this build supports version {FORMAT_VERSION})"
+                )
+            }
+            VtrError::InvalidUtf8(e) => write!(f, "Invalid UTF-8 in object name: {e}"),
+            VtrError::UnknownGeometryTag(tag) => {
+                write!(f, "Unknown geometry tag byte: {tag:#04x}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VtrError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            VtrError::Io(e) => Some(e),
+            VtrError::InvalidUtf8(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<io::Error> for VtrError {
+    fn from(e: io::Error) -> Self {
+        VtrError::Io(e)
+    }
+}
+
+impl From<std::string::FromUtf8Error> for VtrError {
+    fn from(e: std::string::FromUtf8Error) -> Self {
+        VtrError::InvalidUtf8(e)
+    }
+}
+
+// Byte helpers
+
+#[inline]
+fn w_u16(w: &mut impl Write, v: u16) -> io::Result<()> {
+    w.write_all(&v.to_le_bytes())
+}
+
+#[inline]
+fn w_u32(w: &mut impl Write, v: u32) -> io::Result<()> {
+    w.write_all(&v.to_le_bytes())
+}
+
+#[inline]
+fn w_f32(w: &mut impl Write, v: f32) -> io::Result<()> {
+    w.write_all(&v.to_le_bytes())
+}
+
+#[inline]
+fn w_f32x3(w: &mut impl Write, v: [f32; 3]) -> io::Result<()> {
+    w_f32(w, v[0])?;
+    w_f32(w, v[1])?;
+    w_f32(w, v[2])
+}
+
+#[inline]
+fn w_f32x4(w: &mut impl Write, v: [f32; 4]) -> io::Result<()> {
+    w_f32(w, v[0])?;
+    w_f32(w, v[1])?;
+    w_f32(w, v[2])?;
+    w_f32(w, v[3])
+}
+
+#[inline]
+fn r_u16(r: &mut impl Read) -> io::Result<u16> {
+    let mut b = [0u8; 2];
+    r.read_exact(&mut b)?;
+    Ok(u16::from_le_bytes(b))
+}
+
+#[inline]
+fn r_u32(r: &mut impl Read) -> io::Result<u32> {
+    let mut b = [0u8; 4];
+    r.read_exact(&mut b)?;
+    Ok(u32::from_le_bytes(b))
+}
+
+#[inline]
+fn r_f32(r: &mut impl Read) -> io::Result<f32> {
+    let mut b = [0u8; 4];
+    r.read_exact(&mut b)?;
+    Ok(f32::from_le_bytes(b))
+}
+
+#[inline]
+fn r_f32x3(r: &mut impl Read) -> io::Result<[f32; 3]> {
+    Ok([r_f32(r)?, r_f32(r)?, r_f32(r)?])
+}
+
+#[inline]
+fn r_f32x4(r: &mut impl Read) -> io::Result<[f32; 4]> {
+    Ok([r_f32(r)?, r_f32(r)?, r_f32(r)?, r_f32(r)?])
+}
+
+// Geometry encoding
+
+/// Geometry tag byte values.
+mod tag {
+    pub const NONE: u8 = 0;
+    pub const CUBE: u8 = 1;
+    pub const BOX: u8 = 2;
+    pub const PLANE: u8 = 3;
+    pub const PYRAMID: u8 = 4;
+    pub const CAPSULE: u8 = 5;
+    pub const SPHERE: u8 = 6;
+}
+
+fn write_geometry(w: &mut impl Write, geom: &Option<Geometry>) -> io::Result<()> {
+    match geom {
+        None => w.write_all(&[tag::NONE]),
+        Some(Geometry::Cube { size }) => {
+            w.write_all(&[tag::CUBE])?;
+            w_f32(w, *size)
+        }
+        Some(Geometry::Box { width, height, depth }) => {
+            w.write_all(&[tag::BOX])?;
+            w_f32(w, *width)?;
+            w_f32(w, *height)?;
+            w_f32(w, *depth)
+        }
+        Some(Geometry::Plane { size }) => {
+            w.write_all(&[tag::PLANE])?;
+            w_f32(w, *size)
+        }
+        Some(Geometry::Pyramid { base_size, height }) => {
+            w.write_all(&[tag::PYRAMID])?;
+            w_f32(w, *base_size)?;
+            w_f32(w, *height)
+        }
+        Some(Geometry::Capsule { radius, height, subdivisions }) => {
+            w.write_all(&[tag::CAPSULE])?;
+            w_f32(w, *radius)?;
+            w_f32(w, *height)?;
+            w_u32(w, *subdivisions as u32)
+        }
+        Some(Geometry::Sphere { radius, subdivisions }) => {
+            w.write_all(&[tag::SPHERE])?;
+            w_f32(w, *radius)?;
+            w_u32(w, *subdivisions as u32)
+        }
+    }
+}
+
+fn read_geometry(r: &mut impl Read) -> Result<Option<Geometry>, VtrError> {
+    let mut buf = [0u8; 1];
+    r.read_exact(&mut buf)?;
+    match buf[0] {
+        tag::NONE => Ok(None),
+        tag::CUBE => Ok(Some(Geometry::Cube { size: r_f32(r)? })),
+        tag::BOX => Ok(Some(Geometry::Box {
+            width: r_f32(r)?,
+            height: r_f32(r)?,
+            depth: r_f32(r)?,
+        })),
+        tag::PLANE => Ok(Some(Geometry::Plane { size: r_f32(r)? })),
+        tag::PYRAMID => Ok(Some(Geometry::Pyramid {
+            base_size: r_f32(r)?,
+            height: r_f32(r)?,
+        })),
+        tag::CAPSULE => Ok(Some(Geometry::Capsule {
+            radius: r_f32(r)?,
+            height: r_f32(r)?,
+            subdivisions: r_u32(r)? as usize,
+        })),
+        tag::SPHERE => Ok(Some(Geometry::Sphere {
+            radius: r_f32(r)?,
+            subdivisions: r_u32(r)? as usize,
+        })),
+        unknown => Err(VtrError::UnknownGeometryTag(unknown)),
+    }
+}
+
+// Public API
+/// Read only the 20-byte file header from any [`Read`] source.
+///
+/// Useful for quickly inspecting engine/format version info without loading
+/// the entire scene.
+pub fn read_header(r: &mut impl Read) -> Result<VtrHeader, VtrError> {
+    let mut magic = [0u8; 4];
+    r.read_exact(&mut magic)?;
+    if magic != MAGIC {
+        return Err(VtrError::InvalidMagic);
+    }
+    let format_version = r_u16(r)?;
+    if format_version != FORMAT_VERSION {
+        return Err(VtrError::UnsupportedVersion { found: format_version });
+    }
+    let engine_major = r_u16(r)?;
+    let engine_minor = r_u16(r)?;
+    let engine_patch = r_u16(r)?;
+    let _flags = r_u32(r)?; // reserved
+    let object_count = r_u32(r)?;
+
+    Ok(VtrHeader {
+        format_version,
+        engine_major,
+        engine_minor,
+        engine_patch,
+        object_count,
+    })
+}
+
+/// Serialize a complete scene to any [`Write`] sink.
+///
+/// Objects are written in ascending `id` order so the binary output is
+/// deterministic for the same scene regardless of HashMap iteration order.
+pub fn write(w: &mut impl Write, camera: &Camera, world: &World) -> Result<(), VtrError> {
+    // ── Header ──────────────────────────────────────────────────────────────
+    w.write_all(&MAGIC)?;
+    w_u16(w, FORMAT_VERSION)?;
+    w_u16(w, ENGINE_VERSION_MAJOR)?;
+    w_u16(w, ENGINE_VERSION_MINOR)?;
+    w_u16(w, ENGINE_VERSION_PATCH)?;
+    w_u32(w, 0)?; // flags - reserved, must be zero
+    w_u32(w, world.objects.len() as u32)?;
+
+    // Camera
+    w_f32x3(w, camera.eye)?;
+    w_f32x3(w, camera.target)?;
+    w_f32x3(w, camera.up)?;
+    w_f32(w, camera.aspect)?;
+    w_f32(w, camera.fov)?;
+    w_f32(w, camera.znear)?;
+    w_f32(w, camera.zfar)?;
+    w_f32(w, camera.lr_rot)?;
+    w_f32(w, camera.ud_rot)?;
+
+    // Roots
+    // Store the ordered root list explicitly so load-time order is preserved.
+    w_u32(w, world.roots.len() as u32)?;
+    for &root_id in &world.roots {
+        w_u32(w, root_id as u32)?;
+    }
+
+    // Objects
+    // Sort by id for deterministic output.
+    let mut ids: Vec<usize> = world.objects.keys().copied().collect();
+    ids.sort_unstable();
+
+    for id in ids {
+        let obj = &world.objects[&id];
+
+        w_u32(w, id as u32)?;
+        w_u32(w, obj.parent.map(|p| p as u32).unwrap_or(NO_PARENT))?;
+
+        let name_bytes = obj.name.as_bytes();
+        w_u16(w, name_bytes.len() as u16)?;
+        w.write_all(name_bytes)?;
+
+        let bytes = obj.str_id.as_bytes();
+        w_u16(w, bytes.len() as u16)?;
+        w.write_all(bytes)?;
+
+        w_f32x3(w, obj.transform.position)?;
+        w_f32x3(w, obj.transform.rotation)?;
+        w_f32x3(w, obj.transform.scale)?;
+
+        w_f32x4(w, obj.color)?;
+
+        write_geometry(w, &obj.geometry)?;
+
+        w_u32(w, obj.children.len() as u32)?;
+        for &child_id in &obj.children {
+            w_u32(w, child_id as u32)?;
+        }
+    }
+
+    w.flush()?;
+    Ok(())
+}
+
+/// Deserialize a complete scene from any [`Read`] source.
+pub fn read(r: &mut impl Read) -> Result<SceneData, VtrError> {
+    // Header
+    let header = read_header(r)?;
+    let object_count = header.object_count as usize;
+
+    // Camera
+    let camera = Camera {
+        eye: r_f32x3(r)?,
+        target: r_f32x3(r)?,
+        up: r_f32x3(r)?,
+        aspect: r_f32(r)?,
+        fov: r_f32(r)?,
+        znear: r_f32(r)?,
+        zfar: r_f32(r)?,
+        lr_rot: r_f32(r)?,
+        ud_rot: r_f32(r)?,
+    };
+
+    // Roots
+    let roots_count = r_u32(r)? as usize;
+    let mut roots = Vec::with_capacity(roots_count);
+    for _ in 0..roots_count {
+        roots.push(r_u32(r)? as usize);
+    }
+
+    // Objects
+    let mut objects: HashMap<usize, Object> = HashMap::with_capacity(object_count);
+    let mut max_id: usize = 0;
+
+    for _ in 0..object_count {
+        let id = r_u32(r)? as usize;
+        let parent_raw = r_u32(r)?;
+        let parent = if parent_raw == NO_PARENT {
+            None
+        } else {
+            Some(parent_raw as usize)
+        };
+
+        let name_len = r_u16(r)? as usize;
+        let mut name_bytes = vec![0u8; name_len];
+        r.read_exact(&mut name_bytes)?;
+        let name = String::from_utf8(name_bytes)?;
+
+        let str_id_len = r_u16(r)? as usize;
+
+        let mut sid_bytes = vec![0u8; str_id_len];
+        r.read_exact(&mut sid_bytes)?;
+        let str_id = Some(String::from_utf8(sid_bytes)?);
+
+        let position = r_f32x3(r)?;
+        let rotation = r_f32x3(r)?;
+        let scale = r_f32x3(r)?;
+        let color = r_f32x4(r)?;
+        let geometry = read_geometry(r)?;
+
+        let children_count = r_u32(r)? as usize;
+        let mut children = Vec::with_capacity(children_count);
+        for _ in 0..children_count {
+            children.push(r_u32(r)? as usize);
+        }
+
+        if id > max_id {
+            max_id = id;
+        }
+
+        objects.insert(
+            id,
+            Object {
+                name,
+                str_id: str_id.unwrap(),
+                transform: Transform { position, rotation, scale },
+                geometry,
+                color,
+                children,
+                parent,
+            },
+        );
+    }
+
+    // next_id must be greater than every existing id so future spawns never
+    // collide with the loaded objects.
+    let next_id = if objects.is_empty() { 0 } else { max_id + 1 };
+    let world = World::from_parts(objects, roots, next_id);
+
+    Ok(SceneData { camera, world })
+}
+
+/// Write a scene to a file at the given path, creating or truncating it.
+pub fn write_to_file(path: &Path, camera: &Camera, world: &World) -> Result<(), VtrError> {
+    let file = File::create(path)?;
+    let mut writer = BufWriter::new(file);
+    write(&mut writer, camera, world)
+}
+
+/// Read a scene from a `.vtr` file at the given path.
+pub fn read_from_file(path: &Path) -> Result<SceneData, VtrError> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+    read(&mut reader)
+}
+
+/// Peek at the header of a `.vtr` file without loading the scene.
+pub fn header_from_file(path: &Path) -> Result<VtrHeader, VtrError> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+    read_header(&mut reader)
+}
+

--- a/src/window.rs
+++ b/src/window.rs
@@ -12,6 +12,12 @@ use crate::scene::Scene;
 use crate::constants::window;
 use crate::world::World;
 
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::JsCast; // Provides .dyn_into()
+
+#[cfg(target_arch = "wasm32")]
+use winit::platform::web::WindowBuilderExtWebSys; // Provides .with_canvas()
+
 pub struct FrameContext {
     pub dt: f32,
 }
@@ -25,6 +31,7 @@ pub struct WindowConfig {
     pub height: u32,
     pub width: u32,
     pub minimum_dimension: [u32; 2],
+    pub canvas_id: Option<String>,
 }
 
 impl Default for WindowConfig {
@@ -34,11 +41,12 @@ impl Default for WindowConfig {
             width: window::DEFAULT_WIDTH,
             height: window::DEFAULT_HEIGHT,
             minimum_dimension: window::MIN_DIMENSION,
+            canvas_id: None,
         }
     }
 }
 
-pub struct Window<S> {
+pub struct Window<S: 'static> {
     pub handle: Option<Arc<winit::window::Window>>,
     state: S,
     config: WindowConfig,
@@ -88,6 +96,11 @@ impl<S> Window<S> {
         self
     }
 
+    pub fn with_canvas_id(mut self, id: impl Into<String>) -> Self {
+        self.config.canvas_id = Some(id.into());
+        self
+    }
+
     // Setters wrap the input in a Box automatically
     pub fn with_event_handler<F>(mut self, function: F) -> Self
     where F: FnMut(&mut S, &mut Scene, Event<()>, &EventLoopWindowTarget<()>) + 'static {
@@ -128,23 +141,53 @@ impl<S> Window<S> {
     pub fn create(mut self) {
         let event_loop = EventLoop::new().unwrap();
 
-        let winit_window = WindowBuilder::new()
+        let mut builder = WindowBuilder::new()
             .with_inner_size(PhysicalSize::new(self.config.width, self.config.height))
             .with_min_inner_size(PhysicalSize::new(
                 self.config.minimum_dimension[0], self.config.minimum_dimension[1]
             ))
-            .with_title(self.config.title)
-            .build(&event_loop)
-            .unwrap();
+            .with_title(self.config.title.clone());
 
+        #[cfg(target_arch = "wasm32")]
+        {
+            if let Some(id) = &self.config.canvas_id {
+                let canvas = web_sys::window()
+                    .and_then(|win| win.document())
+                    .and_then(|doc| doc.get_element_by_id(id))
+                    .and_then(|ent| ent.dyn_into::<web_sys::HtmlCanvasElement>().ok())
+                    .expect("Could not find canvas with the provided ID");
 
-        let mesh_registry = MeshRegistry::new();
+                builder = builder.with_canvas(Some(canvas));
+            }
+        }
+        let winit_window = builder.build(&event_loop).unwrap();
         let window_handle = Arc::new(winit_window);
-        let pipeline = Pipeline::initialize(Arc::clone(&window_handle));
-
         self.handle = Some(Arc::clone(&window_handle));
 
-        let mut last_update_inst = std::time::Instant::now();
+        #[cfg(target_arch = "wasm32")]
+        {
+            // We clone what we need to move into the async block
+            let window_handle_clone = Arc::clone(&window_handle);
+
+            wasm_bindgen_futures::spawn_local(async move {
+                // 1. Wait for GPU/Pipeline to initialize
+                let pipeline = Pipeline::initialize(Arc::clone(&window_handle_clone)).await;
+
+                // 2. Start the loop!
+                self.run_loop(event_loop, pipeline, window_handle_clone);
+            });
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            // On Desktop, we block locally just for the init, then run the loop
+            let pipeline = pollster::block_on(Pipeline::initialize(Arc::clone(&window_handle)));
+            self.run_loop(event_loop, pipeline, window_handle);
+        }
+    }
+    fn run_loop(mut self, event_loop: EventLoop<()>, pipeline: Pipeline, window_handle: Arc<winit::window::Window>) {
+        let mesh_registry = MeshRegistry::new();
+        let mut last_update_inst = web_time::Instant::now();
         let camera = self.camera.unwrap_or_else(|| {
             Camera::new().with_aspect(self.config.width as f32 / self.config.height as f32)
         });
@@ -159,8 +202,8 @@ impl<S> Window<S> {
         }
         let mut accumulator = 0.0;
 
-        event_loop.run(move |event, elwt| {
-            let now = std::time::Instant::now();
+        let main_loop = move |event: Event<()>, elwt: &EventLoopWindowTarget<()>| {
+            let now = web_time::Instant::now();
             let dt = now.duration_since(last_update_inst).as_secs_f32();
             last_update_inst = now;
 
@@ -172,12 +215,13 @@ impl<S> Window<S> {
             if let Some(event_handler) = &mut self.event_handler {
                 event_handler(&mut self.state, &mut scene, event.clone(), elwt);
             }
+
             match event {
                 Event::AboutToWait => {
                     accumulator += dt;
                     while accumulator >= window::FIXED_DELTA {
                         if let Some(fixed_update) = &mut self.on_fixed_update_fn {
-                            fixed_update(&mut self.state, &mut scene, &mut FrameContext {dt: window::FIXED_DELTA});
+                            fixed_update(&mut self.state, &mut scene, &mut FrameContext { dt: window::FIXED_DELTA });
                         }
                         accumulator -= window::FIXED_DELTA;
                     }
@@ -201,6 +245,18 @@ impl<S> Window<S> {
                     }
                 }
                 _ => (),
-            }}).unwrap();
+            }
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            event_loop.run(main_loop).unwrap();
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            use winit::platform::web::EventLoopExtWebSys;
+            event_loop.spawn(main_loop);
+        }
     }
 }
+

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use crate::objects::Object;
 
+#[derive(Debug)]
 pub struct World {
     pub objects: HashMap<usize, Object>,
     pub roots: Vec<usize>,
@@ -14,6 +15,22 @@ impl World {
             roots: Vec::new(),
             next_id: 0,
         }
+    }
+
+    /// Reconstruct a `World` directly from its constituent parts.
+    ///
+    /// Used by the VTR deserializer to rebuild a world without going through
+    /// `spawn_object`, so that the original IDs and hierarchy are preserved
+    /// exactly.
+    ///
+    /// `next_id` should be set to `max(existing_ids) + 1` so that future
+    /// calls to `spawn_object` never collide with the loaded objects.
+    pub fn from_parts(
+        objects: HashMap<usize, Object>,
+        roots: Vec<usize>,
+        next_id: usize,
+    ) -> Self {
+        Self { objects, roots, next_id }
     }
 
     pub fn spawn_object(&mut self, mut object: Object, parent_id: Option<usize>) -> usize {

--- a/src/world.rs
+++ b/src/world.rs
@@ -44,8 +44,8 @@ impl World {
         let id = self.next_id;
         self.next_id += 1;
 
+        self.name_handles.insert(object.str_id.clone(), id);
         object.parent = parent_id;
-
         // If it has a parent, link the child to the parent
         if let Some(p_id) = parent_id {
             if let Some(parent_obj) = self.objects.get_mut(&p_id) {
@@ -93,6 +93,7 @@ impl World {
     fn recursive_remove(&mut self, id: usize) {
         // Remove the object and take ownership of its children list
         if let Some(obj) = self.objects.remove(&id) {
+            self.name_handles.remove(&obj.str_id);
             for child_id in obj.children {
                 self.recursive_remove(child_id);
             }
@@ -101,9 +102,11 @@ impl World {
 
     pub fn delete(&mut self, id: usize) {
         if let Some(obj) = self.objects.remove(&id) {
+            self.name_handles.remove(&obj.str_id);
             if let Some(p_id) = obj.parent {
                 if let Some(parent) = self.objects.get_mut(&p_id) {
                     parent.children.retain(|&child_id| child_id != id);
+
                 }
             } else {
                 self.roots.retain(|&root_id| root_id != id);

--- a/src/world.rs
+++ b/src/world.rs
@@ -5,6 +5,7 @@ use crate::objects::Object;
 pub struct World {
     pub objects: HashMap<usize, Object>,
     pub roots: Vec<usize>,
+    pub name_handles: HashMap<String, usize>,
     next_id: usize,
 }
 
@@ -14,6 +15,7 @@ impl World {
             objects: HashMap::new(),
             roots: Vec::new(),
             next_id: 0,
+            name_handles: HashMap::new(),
         }
     }
 
@@ -30,7 +32,12 @@ impl World {
         roots: Vec<usize>,
         next_id: usize,
     ) -> Self {
-        Self { objects, roots, next_id }
+        let mut name_handles = HashMap::with_capacity(objects.len());
+
+        for (&id, obj) in &objects {
+            name_handles.insert(obj.str_id.clone(), id);
+        }
+        Self { objects, roots, next_id, name_handles }
     }
 
     pub fn spawn_object(&mut self, mut object: Object, parent_id: Option<usize>) -> usize {
@@ -51,6 +58,32 @@ impl World {
 
         self.objects.insert(id, object);
         id
+    }
+
+    /// Returns the unique integer ID associated with a given string identifier (`str_id`).
+    ///
+    /// This method performs a lookup in the internal handle cache. While the lookup is
+    /// technically $O(1)$ on average, it involves hashing the input string and searching
+    /// a `HashMap`.
+    ///
+    /// # Performance Warning
+    ///
+    /// **Do not use this method inside `on_update` or other high-frequency loops.**
+    ///
+    /// Calling this every frame for multiple objects will cause significant performance
+    /// degradation due to repeated string hashing and cache misses. Instead, "memoize"
+    /// the ID: call this method once during `on_startup`, store the resulting `usize`
+    /// in your application state, and use that integer ID for direct access during updates.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // Correct: Resolve once during initialization
+    /// let sun_id = scene.get_id("sun_center").expect("Sun not found in scene!");
+    /// state.sun_id = Some(sun_id);
+    /// ```
+    pub fn get_id(&self, str_id: &str) -> Option<usize> {
+        self.name_handles.get(str_id).copied()
     }
 
     pub fn get_mut(&mut self, id: usize) -> Option<&mut Object> {


### PR DESCRIPTION
This pull request introduces a new `binder` crate to provide a WebAssembly (WASM) JavaScript API for the `vertra` engine, enabling 3D scene creation and manipulation from JavaScript. It adds Rust bindings for core engine components like cameras, objects, transforms, geometry, and scenes, and sets up the workspace for multi-crate development. The changes also update dependencies and project configuration to support WASM and JavaScript interoperability.

**Workspace and Project Configuration:**

- Added a Cargo workspace and included the new `binder` crate for WASM bindings, updated the `vertra` crate version, and added relevant dependencies for web and serialization support (`wasm-bindgen`, `serde`, `uuid`, etc.). (`Cargo.toml`)
- Created `binder/Cargo.toml` to define the new crate, its dependencies, and library settings for WASM output. (`binder/Cargo.toml`)

**WASM Bindings for Engine Components:**

- Implemented the `Camera` WASM binding, exposing camera configuration, movement, and rotation to JavaScript, including TypeScript interface definitions for options. (`binder/src/camera.rs`)
- Added `Geometry` bindings to create primitive shapes (cube, box, plane, sphere, pyramid) from JavaScript. (`binder/src/geometry.rs`)
- Exposed `Transform` struct for position, rotation, and scale control, with options parsing from JavaScript and methods for combining transforms. (`binder/src/transform.rs`)
- Provided `Object` bindings for scene graph nodes, allowing creation, property updates, and geometry/color assignment from JavaScript, with TypeScript interface for options. (`binder/src/objects.rs`)
- Added `Scene` bindings for managing scene objects, accessing the world and camera, and serializing/deserializing scenes to a binary format. (`binder/src/scene.rs`)

**Binder Crate Structure:**

- Set up the module structure for the binder crate, exposing camera and window modules, and including objects, geometry, world, transform, and scene modules. (`binder/src/lib.rs`)