### PR TITLE
Add scene graph event handling with callbacks for object modifications

### DIFF
--- a/binder/WASM_API.md
+++ b/binder/WASM_API.md
@@ -1,0 +1,384 @@
+# Vertra WASM API Reference
+
+The `vertra-binder` crate compiles to a WebAssembly module that exposes Vertra's
+scene editor to JavaScript / TypeScript.
+
+---
+
+## Quick start
+
+```bash
+# Build the WASM package (requires wasm-pack)
+wasm-pack build --target web --out-dir pkg
+```
+
+```html
+<canvas id="vertra-canvas" width="1280" height="720"></canvas>
+<script type="module">
+import init, { WebWindow, Camera } from './pkg/vertra_binder.js';
+
+await init();
+
+const cam = new Camera();
+cam.set_position(0, 8, -12);
+cam.set_rotation(90, -30);
+
+const win = new WebWindow(cam, { /* your state */ });
+
+win.on_startup((state, scene, ctx) => {
+    scene.enable_editor_mode();
+
+    const sun = /* build an Object */;
+    const sunId = scene.spawn(sun, null);
+});
+
+win.on_update((state, scene, ctx) => {
+    // per-frame logic
+});
+
+win.on_select(data => {
+    // data is InspectorData | undefined
+    if (data) console.log('Selected:', data.name, data.id);
+});
+
+win.start('vertra-canvas');
+</script>
+```
+
+---
+
+## `WebWindow`
+
+The top-level application controller.
+
+### Constructor
+
+```ts
+new WebWindow(camera: Camera, state?: any): WebWindow
+```
+
+| Parameter | Type     | Description                                   |
+|-----------|----------|-----------------------------------------------|
+| `camera`  | `Camera` | Initial camera (position, rotation, FOV, …)  |
+| `state`   | `any`    | Arbitrary JS object forwarded to every callback |
+
+### Lifecycle callbacks
+
+| Method                                      | Signature                                    | When called                   |
+|---------------------------------------------|----------------------------------------------|-------------------------------|
+| `on_startup(f)`                             | `(state, scene, ctx) => void`                | Once before the first frame   |
+| `on_update(f)`                              | `(state, scene, ctx) => void`                | Every frame                   |
+| `on_draw_request(f)`                        | `(state, scene, ctx) => void`                | When a redraw is needed       |
+| `with_event_handler(f)`                     | `(state, scene, event) => void`              | Every browser input event     |
+| `on_select(f)`                              | `(data: InspectorData \| undefined) => void` | Inspector selection changes   |
+
+`FrameContext` has a single field:
+```ts
+interface FrameContext { dt: number; } // seconds since last frame
+```
+
+### `start(canvas_id: string)`
+
+Initialises the WebGPU pipeline and begins the render loop against the given
+`<canvas>` element.  **Call this last**, after registering all callbacks.
+
+---
+
+## `Scene`
+
+Returned to every callback; wraps the live scene graph.
+
+### Object management
+
+```ts
+scene.spawn(object: VertraObject, parent_id?: number): number
+```
+Adds an object to the scene.  Returns the new integer ID.
+
+### Camera
+
+```ts
+scene.camera   // getter → Camera (wraps scene's camera)
+```
+
+### World
+
+```ts
+scene.world    // getter → World  (wraps scene's world graph)
+```
+
+### Editor
+
+```ts
+scene.editor   // getter → Editor (wraps editor state)
+```
+
+---
+
+## Editor mode
+
+### Enable
+
+```ts
+scene.enable_editor_mode(): void
+```
+
+Call once from `on_startup`.  Activates orbit / pan / zoom camera controls,
+object picking, gizmo overlay, and the golden selection box.
+
+```ts
+scene.editor.is_editor_mode(): boolean
+```
+
+---
+
+## Selection
+
+All selection APIs live under `scene.editor`.
+
+### Inspector (primary selection)
+
+```ts
+scene.editor.inspector(): InspectorData | undefined
+scene.editor.clear_inspector(): void
+```
+
+`InspectorData` shape:
+
+```ts
+interface InspectorData {
+    id:           number;
+    name:         string;
+    str_id:       string;
+    position:     [number, number, number];
+    rotation_deg: [number, number, number];
+    scale:        [number, number, number];
+    color:        [number, number, number, number];
+    geometry_type: string | null;
+    texture_path:  string | null;
+}
+```
+
+### Multi-selection (Ctrl+Click / programmatic)
+
+| Method                                         | Description                                       |
+|------------------------------------------------|---------------------------------------------------|
+| `scene.editor.multi_selected_ids(): number[]`  | All IDs currently in the multi-selection         |
+| `scene.editor.is_multi_selected(id): boolean`  | True if `id` is in the current multi-selection  |
+| `scene.editor.set_multi_selected(ids: number[])` | Replace the multi-selection programmatically  |
+| `scene.editor.clear_selection()`               | Clear inspector + multi-select + group expansion  |
+
+```ts
+// Programmatically select two objects and move them together
+scene.editor.set_multi_selected([sunId, planetId]);
+// Now dragging the gizmo moves both objects simultaneously.
+```
+
+### Group expansion (G key)
+
+```ts
+scene.editor.group_ids(): number[]   // IDs in the current G-key expansion
+```
+
+Pressing **G** while an object is selected recursively adds all its children and
+grandchildren to the group.  The gold bounding box and gizmo then encompass the
+entire sub-tree.  A plain click clears the group.
+
+---
+
+## Camera controls (editor mode)
+
+| Action              | Input                       |
+|---------------------|-----------------------------|
+| Free-look rotate    | **Alt** + left-drag         |
+| Pan                 | Middle-drag                 |
+| Zoom                | Scroll wheel                |
+| WASD fly            | W / A / S / D               |
+| Fast fly            | **Shift** + WASD (3×)       |
+| Focus on selection  | **F**                       |
+| Expand to children  | **G**                       |
+
+```ts
+scene.editor.set_camera_speed(10.0);  // world units / second  (default: 5.0)
+scene.editor.set_pivot(x, y, z);      // manually reposition the orbit pivot
+scene.editor.get_pivot();             // → [x, y, z] | undefined
+```
+
+---
+
+## Forwarding input events
+
+If your canvas is inside a custom UI shell that intercepts raw events, forward
+them manually via `scene.editor.editor_event(payload)`.
+
+`payload` must match `EditorEventPayload`:
+
+```ts
+type EditorEventPayload =
+  | { type: "mouse_motion";  dx: number; dy: number }
+  | { type: "cursor_moved";  x: number;  y: number  }
+  | { type: "mouse_button";  left?: boolean; middle?: boolean; right?: boolean }
+  | { type: "scroll";        delta: number }
+  | { type: "modifiers";     alt: boolean; ctrl: boolean }
+  | { type: "focus_key" }
+  | { type: "key_pressed";   code: string }  // winit KeyCode string, e.g. "KeyW"
+  | { type: "key_released";  code: string };
+```
+
+### Wiring example (pointer-lock)
+
+```ts
+canvas.addEventListener('pointermove', e => {
+    scene.editor.editor_event({ type: 'cursor_moved', x: e.clientX, y: e.clientY });
+    scene.editor.editor_event({ type: 'mouse_motion', dx: e.movementX, dy: e.movementY });
+});
+
+canvas.addEventListener('mousedown', e => {
+    scene.editor.editor_event({ type: 'mouse_button', left: e.button === 0 ? true : undefined });
+});
+
+canvas.addEventListener('mouseup', e => {
+    scene.editor.editor_event({ type: 'mouse_button', left: e.button === 0 ? false : undefined });
+});
+
+canvas.addEventListener('wheel', e => {
+    scene.editor.editor_event({ type: 'scroll', delta: -e.deltaY * 0.01 });
+});
+
+// Send modifiers on EVERY keydown/up so the state is always current
+const sendMods = e =>
+    scene.editor.editor_event({ type: 'modifiers', alt: e.altKey, ctrl: e.ctrlKey });
+
+window.addEventListener('keydown', e => {
+    sendMods(e);
+    scene.editor.editor_event({ type: 'key_pressed',  code: e.code });
+});
+window.addEventListener('keyup', e => {
+    sendMods(e);
+    scene.editor.editor_event({ type: 'key_released', code: e.code });
+});
+```
+
+### Supported key codes
+
+Key code strings follow winit's `KeyCode` debug representation:
+
+| Keys                      | Strings                                              |
+|---------------------------|------------------------------------------------------|
+| Letters                   | `"KeyA"` … `"KeyZ"`                                 |
+| Shift                     | `"ShiftLeft"`, `"ShiftRight"`                       |
+| Control                   | `"ControlLeft"`, `"ControlRight"`                   |
+| Alt                       | `"AltLeft"`, `"AltRight"`                           |
+| Arrows                    | `"ArrowUp"`, `"ArrowDown"`, `"ArrowLeft"`, `"ArrowRight"` |
+| Misc                      | `"Space"`, `"Escape"`                               |
+
+> **Tip:** `e.code` from browser `KeyboardEvent` already produces the same
+> strings (`"KeyW"`, `"ShiftLeft"`, …), so you can pass it directly.
+
+---
+
+## Scene persistence (VTR format)
+
+```ts
+// Export
+const bytes: Uint8Array = scene.save_vtr();
+
+// Import
+await scene.load_vtr(bytes);
+```
+
+The VTR binary format preserves the full scene hierarchy, all object transforms,
+colours, **texture paths**, and the camera state.
+
+---
+
+## Textures
+
+Textures are identified by a string key that **must match** the `texture_path`
+property of the objects that should display them.
+
+### Loading a texture
+
+The browser has no direct file-system access, so you must decode the image
+yourself and hand the raw RGBA pixels to the engine:
+
+```ts
+// 1. Fetch + decode
+const blob    = await fetch('assets/texture.png').then(r => r.blob());
+const img     = await createImageBitmap(blob);
+
+// 2. Draw into an OffscreenCanvas to extract raw RGBA bytes
+const cvs     = new OffscreenCanvas(img.width, img.height);
+const ctx2d   = cvs.getContext('2d')!;
+ctx2d.drawImage(img, 0, 0);
+const pixels  = ctx2d.getImageData(0, 0, img.width, img.height);
+
+// 3. Upload to the GPU (called from on_startup or any callback)
+scene.load_texture_from_rgba(
+    'assets/texture.png',   // key — must match VertraObject.texture_path
+    img.width,
+    img.height,
+    pixels.data,            // Uint8ClampedArray: R,G,B,A per pixel
+);
+```
+
+### Applying a texture to an object
+
+Set `texture_path` on the object **before** spawning it, using the same key
+you will later pass to `load_texture_from_rgba`:
+
+```ts
+const obj = new VertraObject('My Cube', {
+    color:        [1, 1, 1, 1],   // white = texture displayed at full fidelity
+    texture_path: 'assets/texture.png',
+});
+obj.set_geometry(new Geometry('cube', 1.5));
+scene.spawn(obj, null);
+```
+
+> **Tip:** you can load textures before or after spawning objects — the
+> engine resolves `texture_path` keys at draw time, so order doesn't matter.
+
+### Texture API reference
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `load_texture_from_rgba` | `(key, width, height, data) => void` | Upload raw RGBA8 pixels |
+| `unload_texture` | `(key) => boolean` | Remove texture; returns `true` if it existed |
+| `has_texture` | `(key) => boolean` | Returns `true` if the key is loaded |
+
+### Full example (startup + texture)
+
+```ts
+win.on_startup(async (state, scene, ctx) => {
+    // Spawn a textured cube
+    const cube = new VertraObject('Cube', {
+        color:        [1, 1, 1, 1],
+        texture_path: 'assets/texture.png',
+    });
+    cube.set_geometry(new Geometry('cube', 2.0));
+    state.cubeId = scene.spawn(cube, null);
+
+    // Load + upload the texture
+    const blob   = await fetch('assets/texture.png').then(r => r.blob());
+    const img    = await createImageBitmap(blob);
+    const cvs    = new OffscreenCanvas(img.width, img.height);
+    const ctx2d  = cvs.getContext('2d')!;
+    ctx2d.drawImage(img, 0, 0);
+    const pixels = ctx2d.getImageData(0, 0, img.width, img.height);
+    scene.load_texture_from_rgba('assets/texture.png', img.width, img.height, pixels.data);
+
+    scene.enable_editor_mode();
+});
+```
+
+---
+
+## TypeScript definitions
+
+All types above are emitted into `pkg/vertra_binder.d.ts` by `wasm-pack`.
+Import them:
+
+```ts
+import type { InspectorData, EditorEventPayload } from './pkg/vertra_binder';
+```

--- a/binder/src/objects.rs
+++ b/binder/src/objects.rs
@@ -159,10 +159,48 @@ impl Object {
         unsafe { (*self.inner).str_id.clone() }
     }
 
+    /// Changes the stable string identifier for this object.
+    ///
+    /// > **Note:** if this object is already part of a [`World`], you must also
+    /// > update the world's name-handle cache by calling
+    /// > [`World::rename_str_id`](crate::world::World) or by re-spawning the
+    /// > object.  Changing `str_id` on a live world object without updating the
+    /// > cache will break [`World::get_id`] lookups for this object.
+    #[wasm_bindgen(setter)]
+    pub fn set_str_id(&mut self, str_id: String) {
+        unsafe { (*self.inner).str_id = str_id; }
+    }
+
+    /// Returns the path to the texture image applied to this object, or
+    /// `undefined` when no texture is set.
+    #[wasm_bindgen(getter)]
+    pub fn texture_path(&self) -> Option<String> {
+        unsafe { (*self.inner).texture_path.clone() }
+    }
+
+    /// Sets (or clears) the texture path for this object.
+    ///
+    /// Pass `undefined` / `null` to remove the texture and fall back to vertex
+    /// colour rendering.  Pass a string matching a key previously registered
+    /// with [`Scene::load_texture_from_rgba`] to apply that texture.
+    #[wasm_bindgen(setter)]
+    pub fn set_texture_path(&mut self, path: Option<String>) {
+        unsafe { (*self.inner).texture_path = path; }
+    }
+
     /// Returns the number of direct children attached to this object.
     #[wasm_bindgen(getter)]
     pub fn children_count(&self) -> usize {
         unsafe { (*self.inner).children.len() }
+    }
+
+    /// Returns the integer IDs of all direct children of this object.
+    ///
+    /// The returned array is a snapshot — mutations made after this call are
+    /// not reflected in the previously returned value.
+    #[wasm_bindgen(getter)]
+    pub fn children(&self) -> Vec<usize> {
+        unsafe { (*self.inner).children.clone() }
     }
 }
 

--- a/binder/src/scene.rs
+++ b/binder/src/scene.rs
@@ -61,9 +61,11 @@ impl Scene {
     ///
     /// The unique integer ID assigned to the new object instance.
     pub fn spawn(&mut self, object: &Object, parent_id: Option<usize>) -> usize {
-        unsafe {
+        let id = unsafe {
             (*self.inner).spawn((*object.inner).clone(), parent_id)
-        }
+        };
+        crate::world::drain_scene_graph_events();
+        id
     }
 
     /// Returns a handle to the underlying [`World`] data structure.

--- a/binder/src/window.rs
+++ b/binder/src/window.rs
@@ -54,7 +54,6 @@ pub struct WebWindow {
     on_startup: Option<Function>,
     on_editor_event: Option<Function>,
     with_event_handler: Option<Function>,
-    on_scene_graph_modified: Option<Function>,
 }
 
 #[wasm_bindgen]
@@ -73,7 +72,6 @@ impl WebWindow {
             on_startup: None,
             on_editor_event: None,
             with_event_handler: None,
-            on_scene_graph_modified: None,
         }
     }
 
@@ -108,17 +106,6 @@ impl WebWindow {
     /// Callback signature: `(event: EditorEventType) => void`
     pub fn on_editor_event(&mut self, f: Function) { self.on_editor_event = Some(f); }
 
-    /// Registers a callback fired whenever the scene graph changes structurally.
-    ///
-    /// Fires on object addition, deletion, or re-parenting.
-    ///
-    /// The event object is a tagged union with a `type` field and a `data` payload:
-    /// - `{ type: "object_added",      data: { id: number, parent_id: number | undefined } }`
-    /// - `{ type: "object_deleted",    data: { id: number } }`
-    /// - `{ type: "object_reparented", data: { id: number, old_parent: number | undefined, new_parent: number | undefined } }`
-    ///
-    /// Callback signature: `(event: SceneGraphModifiedEvent) => void`
-    pub fn on_scene_graph_modified(&mut self, f: Function) { self.on_scene_graph_modified = Some(f); }
 
     /// Initializes the engine and starts the RequestAnimationFrame loop.
     /// @param {string} canvas_id - The ID of the HTMLCanvasElement to target.
@@ -144,10 +131,7 @@ impl WebWindow {
         }
 
         let user_startup = self.on_startup.take();
-        // Always hook on_startup so the scene-graph callback is attached to the
-        // world before any user code runs.
         engine_window = engine_window.on_startup(move |state, scene, _ctx| {
-            crate::world::attach_scene_graph_cb(&mut scene.world);
 
             if let Some(ref f) = user_startup {
                 let frame_ctx = FrameContext { dt: _ctx.dt };
@@ -378,9 +362,6 @@ impl WebWindow {
                 }
             });
         }
-        // Register the scene-graph-modified JS callback in the thread-local so
-        // that any world mutation (spawn / delete / reparent) fires it.
-        crate::world::register_scene_graph_cb(self.on_scene_graph_modified.take());
 
         engine_window.create();
     }

--- a/binder/src/window.rs
+++ b/binder/src/window.rs
@@ -54,6 +54,7 @@ pub struct WebWindow {
     on_startup: Option<Function>,
     on_editor_event: Option<Function>,
     with_event_handler: Option<Function>,
+    on_scene_graph_modified: Option<Function>,
 }
 
 #[wasm_bindgen]
@@ -72,6 +73,7 @@ impl WebWindow {
             on_startup: None,
             on_editor_event: None,
             with_event_handler: None,
+            on_scene_graph_modified: None,
         }
     }
 
@@ -106,6 +108,18 @@ impl WebWindow {
     /// Callback signature: `(event: EditorEventType) => void`
     pub fn on_editor_event(&mut self, f: Function) { self.on_editor_event = Some(f); }
 
+    /// Registers a callback fired whenever the scene graph changes structurally.
+    ///
+    /// Fires on object addition, deletion, or re-parenting.
+    ///
+    /// The event object is a tagged union with a `type` field and a `data` payload:
+    /// - `{ type: "object_added",      data: { id: number, parent_id: number | undefined } }`
+    /// - `{ type: "object_deleted",    data: { id: number } }`
+    /// - `{ type: "object_reparented", data: { id: number, old_parent: number | undefined, new_parent: number | undefined } }`
+    ///
+    /// Callback signature: `(event: SceneGraphModifiedEvent) => void`
+    pub fn on_scene_graph_modified(&mut self, f: Function) { self.on_scene_graph_modified = Some(f); }
+
     /// Initializes the engine and starts the RequestAnimationFrame loop.
     /// @param {string} canvas_id - The ID of the HTMLCanvasElement to target.
     pub fn start(mut self, canvas_id: String) {
@@ -129,8 +143,13 @@ impl WebWindow {
             Scene { inner: scene as *mut vertra::scene::Scene }
         }
 
-        if let Some(f) = self.on_startup {
-            engine_window = engine_window.on_startup(move |state, scene, _ctx| {
+        let user_startup = self.on_startup.take();
+        // Always hook on_startup so the scene-graph callback is attached to the
+        // world before any user code runs.
+        engine_window = engine_window.on_startup(move |state, scene, _ctx| {
+            crate::world::attach_scene_graph_cb(&mut scene.world);
+
+            if let Some(ref f) = user_startup {
                 let frame_ctx = FrameContext { dt: _ctx.dt };
                 let _ = f.call3(
                     &JsValue::UNDEFINED,
@@ -138,8 +157,8 @@ impl WebWindow {
                     &JsValue::from(unsafe { wrap_scene(scene) }),
                     &JsValue::from(frame_ctx)
                 );
-            });
-        }
+            }
+        });
 
         if let Some(f) = self.on_update {
             engine_window = engine_window.on_update(move |state, scene, _ctx| {
@@ -359,6 +378,10 @@ impl WebWindow {
                 }
             });
         }
+        // Register the scene-graph-modified JS callback in the thread-local so
+        // that any world mutation (spawn / delete / reparent) fires it.
+        crate::world::register_scene_graph_cb(self.on_scene_graph_modified.take());
+
         engine_window.create();
     }
 }

--- a/binder/src/world.rs
+++ b/binder/src/world.rs
@@ -101,13 +101,25 @@ impl World {
     /// Pass `undefined` / `null` as `new_parent_id` to move the object to the
     /// scene root.  The object's children are carried along unchanged.
     ///
+    /// Returns `false` and leaves the hierarchy unchanged when any of these
+    /// conditions hold:
+    /// - `id` does not exist.
+    /// - `new_parent_id` does not exist (and is not `null`).
+    /// - `new_parent_id` equals `id` (self-parenting).
+    /// - `new_parent_id` is already the current parent.
+    /// - `new_parent_id` is a descendant of `id` (would create a cycle).
+    ///
     /// # Arguments
     ///
     /// * `id`            - Integer ID of the object to move.
     /// * `new_parent_id` - ID of the new parent, or `undefined` / `null` for root.
-    pub fn reparent(&mut self, id: usize, new_parent_id: Option<usize>) {
+    ///
+    /// # Returns
+    ///
+    /// `true` if the reparent was applied; `false` if it was rejected.
+    pub fn reparent(&mut self, id: usize, new_parent_id: Option<usize>) -> bool {
         unsafe {
-            (*self.inner).reparent(id, new_parent_id);
+            (*self.inner).reparent(id, new_parent_id)
         }
     }
 

--- a/binder/src/world.rs
+++ b/binder/src/world.rs
@@ -176,4 +176,26 @@ impl World {
             (*self.inner).roots.clone()
         }
     }
+
+    /// Renames the stable string identifier of a live world object and keeps
+    /// the internal name-handle cache in sync.
+    ///
+    /// Prefer this over writing to `object.str_id` directly when the object is
+    /// already part of the world, as the world maintains an internal
+    /// `str_id → integer id` lookup table that must stay consistent.
+    ///
+    /// # Arguments
+    ///
+    /// * `id`         - Integer ID of the object to rename.
+    /// * `new_str_id` - The replacement string identifier (should be unique
+    ///   within this world).
+    ///
+    /// # Returns
+    ///
+    /// `true` if the rename succeeded; `false` when `id` does not exist.
+    pub fn rename_str_id(&mut self, id: usize, new_str_id: String) -> bool {
+        unsafe {
+            (*self.inner).rename_str_id(id, new_str_id)
+        }
+    }
 }

--- a/binder/src/world.rs
+++ b/binder/src/world.rs
@@ -7,6 +7,12 @@ use vertra::world::{World as CoreWorld, SceneGraphEvent, SceneGraphCallback};
 thread_local! {
     static SCENE_GRAPH_CB: std::cell::RefCell<Option<Function>> =
         std::cell::RefCell::new(None);
+    /// Pending events accumulated during a world-mutation call.
+    /// They are drained and dispatched to JS only after the `*mut CoreWorld`
+    /// borrow has been fully released, preventing JS re-entrancy from aliasing
+    /// the same pointer as a second `&mut`.
+    static SCENE_GRAPH_QUEUE: std::cell::RefCell<Vec<SceneGraphModifiedEvent>> =
+        std::cell::RefCell::new(Vec::new());
 }
 
 /// Register (or clear) the JS function that receives scene-graph change events.
@@ -27,10 +33,28 @@ pub enum SceneGraphModifiedEvent {
 }
 
 fn fire_scene_graph_event(ev: SceneGraphModifiedEvent) {
+    // Push into the queue; the caller is responsible for draining it once the
+    // mutable world borrow has been released (see `drain_scene_graph_events`).
+    SCENE_GRAPH_QUEUE.with(|q| q.borrow_mut().push(ev));
+}
+
+/// Drain the pending scene-graph event queue and dispatch each event to JS.
+///
+/// Must be called **after** every world-mutating binder call (`spawn_object`,
+/// `delete`, `reparent`) so that the `*mut CoreWorld` raw pointer is no longer
+/// borrowed when JS receives the callback and can potentially re-enter WASM.
+pub(crate) fn drain_scene_graph_events() {
+    let events: Vec<SceneGraphModifiedEvent> =
+        SCENE_GRAPH_QUEUE.with(|q| std::mem::take(&mut *q.borrow_mut()));
+
+    if events.is_empty() { return; }
+
     SCENE_GRAPH_CB.with(|c| {
         if let Some(cb) = c.borrow().as_ref() {
-            if let Ok(js) = serde_wasm_bindgen::to_value(&ev) {
-                let _ = cb.call1(&JsValue::UNDEFINED, &js);
+            for ev in events {
+                if let Ok(js) = serde_wasm_bindgen::to_value(&ev) {
+                    let _ = cb.call1(&JsValue::UNDEFINED, &js);
+                }
             }
         }
     });
@@ -76,9 +100,11 @@ impl World {
     ///
     /// The unique integer ID assigned to the new object instance.
     pub fn spawn_object(&mut self, object: &Object, parent_id: Option<usize>) -> usize {
-        unsafe {
+        let id = unsafe {
             (*self.inner).spawn_object((*object.inner).clone(), parent_id)
-        }
+        };
+        drain_scene_graph_events();
+        id
     }
 
     /// Removes an object and all of its descendants from the world.
@@ -94,6 +120,7 @@ impl World {
         unsafe {
             (*self.inner).delete(id);
         }
+        drain_scene_graph_events();
     }
 
     /// Moves an object to a new parent in the scene hierarchy.
@@ -118,9 +145,11 @@ impl World {
     ///
     /// `true` if the reparent was applied; `false` if it was rejected.
     pub fn reparent(&mut self, id: usize, new_parent_id: Option<usize>) -> bool {
-        unsafe {
+        let result = unsafe {
             (*self.inner).reparent(id, new_parent_id)
-        }
+        };
+        drain_scene_graph_events();
+        result
     }
 
     /// Retrieves a live reference to an object by its integer ID.
@@ -197,5 +226,34 @@ impl World {
         unsafe {
             (*self.inner).rename_str_id(id, new_str_id)
         }
+    }
+
+    /// Registers a callback fired whenever the scene graph changes structurally
+    /// (object added, deleted, or re-parented).
+    ///
+    /// This installs the internal Rust hook on the underlying world **and**
+    /// stores the JS handler — both steps happen in a single call, so you can
+    /// wire it up directly from `on_startup` without touching `WebWindow`:
+    ///
+    /// ```js
+    /// window.on_startup((state, scene) => {
+    ///   scene.world.on_scene_graph_modified(ev => console.log(ev));
+    /// });
+    /// ```
+    ///
+    /// The event object is a tagged union:
+    /// - `{ type: "object_added",      data: { id, parent_id } }`
+    /// - `{ type: "object_deleted",    data: { id } }`
+    /// - `{ type: "object_reparented", data: { id, old_parent, new_parent } }`
+    ///
+    /// Pass `undefined` / `null` to unregister a previously set callback.
+    ///
+    /// Callback signature: `(event: SceneGraphModifiedEvent) => void`
+    pub fn on_scene_graph_modified(&mut self, f: Option<Function>) {
+        register_scene_graph_cb(f);
+        // Install the Rust -> JS bridge on the core world if not already present.
+        // Calling this more than once is harmless; it simply replaces the
+        // existing callback closure with an identical one.
+        unsafe { attach_scene_graph_cb(&mut *self.inner); }
     }
 }

--- a/binder/src/world.rs
+++ b/binder/src/world.rs
@@ -1,6 +1,56 @@
 use wasm_bindgen::prelude::*;
+use js_sys::Function;
+use serde::Serialize;
 use crate::objects::Object;
-use vertra::world::{World as CoreWorld};
+use vertra::world::{World as CoreWorld, SceneGraphEvent, SceneGraphCallback};
+
+thread_local! {
+    static SCENE_GRAPH_CB: std::cell::RefCell<Option<Function>> =
+        std::cell::RefCell::new(None);
+}
+
+/// Register (or clear) the JS function that receives scene-graph change events.
+pub(crate) fn register_scene_graph_cb(f: Option<Function>) {
+    SCENE_GRAPH_CB.with(|c| *c.borrow_mut() = f);
+}
+
+/// Serialisable event sent to JavaScript.
+#[derive(Serialize)]
+#[serde(tag = "type", content = "data")]
+pub enum SceneGraphModifiedEvent {
+    #[serde(rename = "object_added")]
+    ObjectAdded { id: usize, parent_id: Option<usize> },
+    #[serde(rename = "object_deleted")]
+    ObjectDeleted { id: usize },
+    #[serde(rename = "object_reparented")]
+    ObjectReparented { id: usize, old_parent: Option<usize>, new_parent: Option<usize> },
+}
+
+fn fire_scene_graph_event(ev: SceneGraphModifiedEvent) {
+    SCENE_GRAPH_CB.with(|c| {
+        if let Some(cb) = c.borrow().as_ref() {
+            if let Ok(js) = serde_wasm_bindgen::to_value(&ev) {
+                let _ = cb.call1(&JsValue::UNDEFINED, &js);
+            }
+        }
+    });
+}
+
+/// Install the scene-graph callback on a `CoreWorld` so every structural
+/// mutation fires the registered JS handler.
+pub(crate) fn attach_scene_graph_cb(world: &mut CoreWorld) {
+    world.on_scene_graph_modified = Some(SceneGraphCallback(Box::new(|ev: SceneGraphEvent| {
+        let web_ev = match ev {
+            SceneGraphEvent::ObjectAdded { id, parent_id } =>
+                SceneGraphModifiedEvent::ObjectAdded { id, parent_id },
+            SceneGraphEvent::ObjectDeleted { id } =>
+                SceneGraphModifiedEvent::ObjectDeleted { id },
+            SceneGraphEvent::ObjectReparented { id, old_parent, new_parent } =>
+                SceneGraphModifiedEvent::ObjectReparented { id, old_parent, new_parent },
+        };
+        fire_scene_graph_event(web_ev);
+    })));
+}
 
 /// The entity management system and scene hierarchy container.
 ///
@@ -43,6 +93,21 @@ impl World {
     pub fn delete(&mut self, id: usize) {
         unsafe {
             (*self.inner).delete(id);
+        }
+    }
+
+    /// Moves an object to a new parent in the scene hierarchy.
+    ///
+    /// Pass `undefined` / `null` as `new_parent_id` to move the object to the
+    /// scene root.  The object's children are carried along unchanged.
+    ///
+    /// # Arguments
+    ///
+    /// * `id`            - Integer ID of the object to move.
+    /// * `new_parent_id` - ID of the new parent, or `undefined` / `null` for root.
+    pub fn reparent(&mut self, id: usize, new_parent_id: Option<usize>) {
+        unsafe {
+            (*self.inner).reparent(id, new_parent_id);
         }
     }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,4 @@
 mod test_timer;
 mod test_vtr;
+mod test_scene_graph_events;
 

--- a/src/tests/test_scene_graph_events.rs
+++ b/src/tests/test_scene_graph_events.rs
@@ -16,7 +16,7 @@ use crate::world::{SceneGraphCallback, SceneGraphEvent, World};
 fn world_with_log() -> (World, Rc<RefCell<Vec<SceneGraphEvent>>>) {
     let log: Rc<RefCell<Vec<SceneGraphEvent>>> = Rc::new(RefCell::new(Vec::new()));
     let log_clone = Rc::clone(&log);
-    
+
     let mut world = World::new();
     world.on_scene_graph_modified = Some(SceneGraphCallback(Box::new(move |ev| {
         log_clone.borrow_mut().push(ev);
@@ -172,7 +172,7 @@ fn reparent_to_root_sets_new_parent_none() {
         }
         other => panic!("Unexpected event: {other:?}"),
     }
-    
+
     assert!(world.roots.contains(&child));
 }
 
@@ -274,3 +274,44 @@ fn reparent_updates_parent_children_lists() {
     assert_eq!(world.objects[&child].parent, Some(b));
 }
 
+// TODO: Move these test below somewhere else since it's not related to scene graph events
+#[test]
+fn rename_str_id_updates_cache() {
+    let (mut world, _log) = world_with_log();
+    let id = world.spawn_object(default_object("Obj", "old_id"), None);
+
+    let ok = world.rename_str_id(id, "new_id".to_string());
+
+    assert!(ok);
+    assert_eq!(world.get_id("new_id"), Some(id));   // new key resolves
+    assert_eq!(world.get_id("old_id"), None);         // old key is gone
+    assert_eq!(world.objects[&id].str_id, "new_id"); // field is updated
+}
+
+#[test]
+fn rename_str_id_nonexistent_returns_false() {
+    let (mut world, _log) = world_with_log();
+    assert!(!world.rename_str_id(9999, "x".to_string()));
+}
+
+#[test]
+fn direct_field_mutation_desynchronises_cache() {
+    // Documents the hazard: writing obj.str_id directly bypasses the cache.
+    // rename_str_id is the safe path.
+    let (mut world, _log) = world_with_log();
+    let id = world.spawn_object(default_object("Obj", "original"), None);
+
+    // UNSAFE direct mutation - bypasses cache
+    world.objects.get_mut(&id).unwrap().str_id = "bypassed".to_string();
+
+    // Cache still maps "original" -> id; "bypassed" is unknown
+    assert_eq!(world.get_id("original"), Some(id));
+    assert_eq!(world.get_id("bypassed"), None);
+
+    // The safe fix: rename_str_id reads the *current* field value ("bypassed")
+    // as the stale key, removes it (no-op since it wasn't in the cache), then
+    // inserts the correct mapping.
+    let ok = world.rename_str_id(id, "fixed".to_string());
+    assert!(ok);
+    assert_eq!(world.get_id("fixed"), Some(id));
+}

--- a/src/tests/test_scene_graph_events.rs
+++ b/src/tests/test_scene_graph_events.rs
@@ -1,0 +1,188 @@
+//! Unit tests for `World::on_scene_graph_modified`.
+//!
+//! These tests exercise the three structural mutations — `spawn_object`,
+//! `delete`, and `reparent` — and verify that the correct [`SceneGraphEvent`]
+//! variants are fired with the expected payload.
+//!
+//! No window, GPU pipeline, or async runtime is required; the tests run with
+//! plain `cargo test`.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::objects::Object;
+use crate::world::{SceneGraphCallback, SceneGraphEvent, World};
+
+/// Create a minimal [`World`] with a callback that appends every event to a
+/// shared `Vec`.  Returns `(world, event_log)`.
+fn world_with_log() -> (World, Rc<RefCell<Vec<SceneGraphEvent>>>) {
+    let log: Rc<RefCell<Vec<SceneGraphEvent>>> = Rc::new(RefCell::new(Vec::new()));
+    let log_clone = Rc::clone(&log);
+
+    let mut world = World::new();
+    world.on_scene_graph_modified = Some(SceneGraphCallback(Box::new(move |ev| {
+        log_clone.borrow_mut().push(ev);
+    })));
+
+    (world, log)
+}
+
+fn default_object(name: &str, str_id: &str) -> Object {
+    Object {
+        name: name.to_string(),
+        str_id: str_id.to_string(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn spawn_fires_object_added_at_root() {
+    let (mut world, log) = world_with_log();
+
+    let id = world.spawn_object(default_object("Root", "root"), None);
+
+    let events = log.borrow();
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        SceneGraphEvent::ObjectAdded { id: fired_id, parent_id } => {
+            assert_eq!(*fired_id, id);
+            assert_eq!(*parent_id, None);
+        }
+        other => panic!("Unexpected event: {other:?}"),
+    }
+}
+
+#[test]
+fn spawn_fires_object_added_with_parent() {
+    let (mut world, log) = world_with_log();
+
+    let parent_id = world.spawn_object(default_object("Parent", "parent"), None);
+    let child_id  = world.spawn_object(default_object("Child",  "child"),  Some(parent_id));
+
+    let events = log.borrow();
+    // Two additions: parent then child
+    assert_eq!(events.len(), 2);
+
+    match &events[1] {
+        SceneGraphEvent::ObjectAdded { id, parent_id: p } => {
+            assert_eq!(*id, child_id);
+            assert_eq!(*p, Some(parent_id));
+        }
+        other => panic!("Unexpected event: {other:?}"),
+    }
+}
+
+#[test]
+fn delete_fires_object_deleted() {
+    let (mut world, log) = world_with_log();
+
+    let id = world.spawn_object(default_object("ToDelete", "td"), None);
+    log.borrow_mut().clear(); // ignore the spawn event
+
+    world.delete(id);
+
+    let events = log.borrow();
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        SceneGraphEvent::ObjectDeleted { id: fired_id } => {
+            assert_eq!(*fired_id, id);
+        }
+        other => panic!("Unexpected event: {other:?}"),
+    }
+}
+
+#[test]
+fn delete_nonexistent_id_fires_no_event() {
+    let (mut world, log) = world_with_log();
+
+    world.delete(9999);
+    println!("Events: {:?}", log.borrow());
+    assert!(log.borrow().is_empty());
+}
+
+#[test]
+fn reparent_fires_object_reparented() {
+    let (mut world, log) = world_with_log();
+
+    let parent_a = world.spawn_object(default_object("A", "a"), None);
+    let parent_b = world.spawn_object(default_object("B", "b"), None);
+    let child    = world.spawn_object(default_object("C", "c"), Some(parent_a));
+    log.borrow_mut().clear();
+
+    world.reparent(child, Some(parent_b));
+
+    let events = log.borrow();
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        SceneGraphEvent::ObjectReparented { id, old_parent, new_parent } => {
+            assert_eq!(*id, child);
+            assert_eq!(*old_parent, Some(parent_a));
+            assert_eq!(*new_parent, Some(parent_b));
+        }
+        other => panic!("Unexpected event: {other:?}"),
+    }
+}
+
+#[test]
+fn reparent_to_root_sets_new_parent_none() {
+    let (mut world, log) = world_with_log();
+
+    let parent = world.spawn_object(default_object("P", "p"), None);
+    let child  = world.spawn_object(default_object("C", "c"), Some(parent));
+    log.borrow_mut().clear();
+
+    world.reparent(child, None);
+
+    let events = log.borrow();
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        SceneGraphEvent::ObjectReparented { id, old_parent, new_parent } => {
+            assert_eq!(*id, child);
+            assert_eq!(*old_parent, Some(parent));
+            assert_eq!(*new_parent, None);
+            // Object should now appear in roots
+        }
+        other => panic!("Unexpected event: {other:?}"),
+    }
+
+    assert!(world.roots.contains(&child));
+}
+
+#[test]
+fn reparent_same_parent_fires_no_event() {
+    let (mut world, log) = world_with_log();
+
+    let parent = world.spawn_object(default_object("P", "p"), None);
+    let child  = world.spawn_object(default_object("C", "c"), Some(parent));
+    log.borrow_mut().clear();
+
+    world.reparent(child, Some(parent)); // no-op
+
+    assert!(log.borrow().is_empty());
+}
+
+#[test]
+fn reparent_nonexistent_id_fires_no_event() {
+    let (mut world, log) = world_with_log();
+    log.borrow_mut().clear();
+
+    world.reparent(9999, None);
+
+    assert!(log.borrow().is_empty());
+}
+
+#[test]
+fn reparent_updates_parent_children_lists() {
+    let (mut world, _log) = world_with_log();
+
+    let a     = world.spawn_object(default_object("A", "a"), None);
+    let b     = world.spawn_object(default_object("B", "b"), None);
+    let child = world.spawn_object(default_object("C", "c"), Some(a));
+
+    world.reparent(child, Some(b));
+
+    assert!(!world.objects[&a].children.contains(&child), "old parent still owns child");
+    assert!( world.objects[&b].children.contains(&child), "new parent does not own child");
+    assert_eq!(world.objects[&child].parent, Some(b));
+}
+

--- a/src/tests/test_scene_graph_events.rs
+++ b/src/tests/test_scene_graph_events.rs
@@ -13,17 +13,14 @@ use std::rc::Rc;
 use crate::objects::Object;
 use crate::world::{SceneGraphCallback, SceneGraphEvent, World};
 
-/// Create a minimal [`World`] with a callback that appends every event to a
-/// shared `Vec`.  Returns `(world, event_log)`.
 fn world_with_log() -> (World, Rc<RefCell<Vec<SceneGraphEvent>>>) {
     let log: Rc<RefCell<Vec<SceneGraphEvent>>> = Rc::new(RefCell::new(Vec::new()));
     let log_clone = Rc::clone(&log);
-
+    
     let mut world = World::new();
     world.on_scene_graph_modified = Some(SceneGraphCallback(Box::new(move |ev| {
         log_clone.borrow_mut().push(ev);
     })));
-
     (world, log)
 }
 
@@ -60,7 +57,6 @@ fn spawn_fires_object_added_with_parent() {
     let child_id  = world.spawn_object(default_object("Child",  "child"),  Some(parent_id));
 
     let events = log.borrow();
-    // Two additions: parent then child
     assert_eq!(events.len(), 2);
 
     match &events[1] {
@@ -77,8 +73,7 @@ fn delete_fires_object_deleted() {
     let (mut world, log) = world_with_log();
 
     let id = world.spawn_object(default_object("ToDelete", "td"), None);
-    log.borrow_mut().clear(); // ignore the spawn event
-
+    log.borrow_mut().clear();
     world.delete(id);
 
     let events = log.borrow();
@@ -96,20 +91,53 @@ fn delete_nonexistent_id_fires_no_event() {
     let (mut world, log) = world_with_log();
 
     world.delete(9999);
-    println!("Events: {:?}", log.borrow());
     assert!(log.borrow().is_empty());
+}
+
+#[test]
+fn delete_removes_entire_subtree() {
+    let (mut world, log) = world_with_log();
+    //   root
+    //   └── child
+    //       └── grandchild
+    let root  = world.spawn_object(default_object("R", "r"), None);
+    let child = world.spawn_object(default_object("C", "c"), Some(root));
+    let grand = world.spawn_object(default_object("G", "g"), Some(child));
+    log.borrow_mut().clear();
+
+    world.delete(root);
+
+    // All three objects must be gone
+    assert!(!world.objects.contains_key(&root),  "root still present");
+    assert!(!world.objects.contains_key(&child), "child still present");
+    assert!(!world.objects.contains_key(&grand), "grandchild still present");
+    // Root must be removed from the roots list
+    assert!(!world.roots.contains(&root));
+    // One ObjectDeleted event fired for the top-level deletion
+    let events = log.borrow();
+    assert_eq!(events.len(), 1);
+    assert!(matches!(&events[0], SceneGraphEvent::ObjectDeleted { id } if *id == root));
+}
+
+#[test]
+fn delete_child_removes_from_parent_children_list() {
+    let (mut world, _log) = world_with_log();
+    let parent = world.spawn_object(default_object("P", "p"), None);
+    let child  = world.spawn_object(default_object("C", "c"), Some(parent));
+    world.delete(child);
+    assert!(!world.objects[&parent].children.contains(&child));
 }
 
 #[test]
 fn reparent_fires_object_reparented() {
     let (mut world, log) = world_with_log();
-
     let parent_a = world.spawn_object(default_object("A", "a"), None);
     let parent_b = world.spawn_object(default_object("B", "b"), None);
     let child    = world.spawn_object(default_object("C", "c"), Some(parent_a));
     log.borrow_mut().clear();
 
-    world.reparent(child, Some(parent_b));
+    let ok = world.reparent(child, Some(parent_b));
+    assert!(ok);
 
     let events = log.borrow();
     assert_eq!(events.len(), 1);
@@ -131,7 +159,8 @@ fn reparent_to_root_sets_new_parent_none() {
     let child  = world.spawn_object(default_object("C", "c"), Some(parent));
     log.borrow_mut().clear();
 
-    world.reparent(child, None);
+    let ok = world.reparent(child, None);
+    assert!(ok);
 
     let events = log.borrow();
     assert_eq!(events.len(), 1);
@@ -140,11 +169,10 @@ fn reparent_to_root_sets_new_parent_none() {
             assert_eq!(*id, child);
             assert_eq!(*old_parent, Some(parent));
             assert_eq!(*new_parent, None);
-            // Object should now appear in roots
         }
         other => panic!("Unexpected event: {other:?}"),
     }
-
+    
     assert!(world.roots.contains(&child));
 }
 
@@ -156,8 +184,8 @@ fn reparent_same_parent_fires_no_event() {
     let child  = world.spawn_object(default_object("C", "c"), Some(parent));
     log.borrow_mut().clear();
 
-    world.reparent(child, Some(parent)); // no-op
-
+    let ok = world.reparent(child, Some(parent));
+    assert!(!ok);
     assert!(log.borrow().is_empty());
 }
 
@@ -165,9 +193,69 @@ fn reparent_same_parent_fires_no_event() {
 fn reparent_nonexistent_id_fires_no_event() {
     let (mut world, log) = world_with_log();
     log.borrow_mut().clear();
+    let ok = world.reparent(9999, None);
+    assert!(!ok);
+    assert!(log.borrow().is_empty());
+}
 
-    world.reparent(9999, None);
+#[test]
+fn reparent_to_nonexistent_parent_is_noop() {
+    let (mut world, log) = world_with_log();
+    let id = world.spawn_object(default_object("A", "a"), None);
+    log.borrow_mut().clear();
 
+    // 9999 does not exist, must be rejected
+    let ok = world.reparent(id, Some(9999));
+    assert!(!ok, "reparent to nonexistent parent should return false");
+    assert!(log.borrow().is_empty(), "no event should fire");
+    // Object must still be at root
+    assert!(world.roots.contains(&id));
+    assert_eq!(world.objects[&id].parent, None);
+}
+
+#[test]
+fn reparent_self_is_noop() {
+    let (mut world, log) = world_with_log();
+    let id = world.spawn_object(default_object("A", "a"), None);
+    log.borrow_mut().clear();
+
+    let ok = world.reparent(id, Some(id));
+    assert!(!ok);
+    assert!(log.borrow().is_empty());
+}
+
+#[test]
+fn reparent_rejects_direct_cycle() {
+    let (mut world, log) = world_with_log();
+    //   parent -> child
+    // Attempt: reparent parent under child -> would create cycle
+    let parent = world.spawn_object(default_object("P", "p"), None);
+    let child  = world.spawn_object(default_object("C", "c"), Some(parent));
+    log.borrow_mut().clear();
+
+    let ok = world.reparent(parent, Some(child));
+    assert!(!ok, "direct cycle must be rejected");
+    assert!(log.borrow().is_empty());
+
+    // Hierarchy must be unchanged
+    assert!(world.roots.contains(&parent));
+    assert_eq!(world.objects[&parent].parent, None);
+    assert_eq!(world.objects[&child].parent, Some(parent));
+}
+
+#[test]
+fn reparent_rejects_deep_cycle() {
+    let (mut world, log) = world_with_log();
+    //   a -> b -> c -> d
+    let a = world.spawn_object(default_object("A", "a"), None);
+    let b = world.spawn_object(default_object("B", "b"), Some(a));
+    let c = world.spawn_object(default_object("C", "c"), Some(b));
+    let d = world.spawn_object(default_object("D", "d"), Some(c));
+    log.borrow_mut().clear();
+
+    // Reparenting `a` under `d` would make `a` its own descendant
+    let ok = world.reparent(a, Some(d));
+    assert!(!ok, "deep cycle must be rejected");
     assert!(log.borrow().is_empty());
 }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,12 +1,36 @@
 use std::collections::HashMap;
 use crate::objects::Object;
 
+/// Describes a structural change to the scene hierarchy.
+///
+/// Fired whenever objects are added, removed, or re-parented.
+#[derive(Debug, Clone)]
+pub enum SceneGraphEvent {
+    /// A new object was inserted into the world.
+    ObjectAdded { id: usize, parent_id: Option<usize> },
+    /// An object (and all its descendants) was removed.
+    ObjectDeleted { id: usize },
+    /// An object was moved to a different parent (or to/from root level).
+    ObjectReparented { id: usize, old_parent: Option<usize>, new_parent: Option<usize> },
+}
+
+/// Newtype wrapper around a `FnMut(SceneGraphEvent)` that satisfies `Debug`.
+pub struct SceneGraphCallback(pub Box<dyn FnMut(SceneGraphEvent)>);
+
+impl std::fmt::Debug for SceneGraphCallback {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SceneGraphCallback(<fn>)")
+    }
+}
+
 #[derive(Debug)]
 pub struct World {
     pub objects: HashMap<usize, Object>,
     pub roots: Vec<usize>,
     pub name_handles: HashMap<String, usize>,
     next_id: usize,
+    /// Optional callback invoked after every structural scene-graph change.
+    pub on_scene_graph_modified: Option<SceneGraphCallback>,
 }
 
 impl World {
@@ -16,6 +40,7 @@ impl World {
             roots: Vec::new(),
             next_id: 0,
             name_handles: HashMap::new(),
+            on_scene_graph_modified: None,
         }
     }
 
@@ -37,7 +62,7 @@ impl World {
         for (&id, obj) in &objects {
             name_handles.insert(obj.str_id.clone(), id);
         }
-        Self { objects, roots, next_id, name_handles }
+        Self { objects, roots, next_id, name_handles, on_scene_graph_modified: None }
     }
 
     pub fn spawn_object(&mut self, mut object: Object, parent_id: Option<usize>) -> usize {
@@ -57,6 +82,10 @@ impl World {
         }
 
         self.objects.insert(id, object);
+
+        if let Some(cb) = &mut self.on_scene_graph_modified {
+            (cb.0)(SceneGraphEvent::ObjectAdded { id, parent_id });
+        }
         id
     }
 
@@ -101,17 +130,65 @@ impl World {
     }
 
     pub fn delete(&mut self, id: usize) {
-        if let Some(obj) = self.objects.remove(&id) {
+        let existed = if let Some(obj) = self.objects.remove(&id) {
             self.name_handles.remove(&obj.str_id);
             if let Some(p_id) = obj.parent {
                 if let Some(parent) = self.objects.get_mut(&p_id) {
                     parent.children.retain(|&child_id| child_id != id);
-
                 }
             } else {
                 self.roots.retain(|&root_id| root_id != id);
             }
-        }
+            true
+        } else {
+            false
+        };
         self.recursive_remove(id);
+
+        if existed {
+            if let Some(cb) = &mut self.on_scene_graph_modified {
+                (cb.0)(SceneGraphEvent::ObjectDeleted { id });
+            }
+        }
+    }
+
+    /// Move `id` to a new parent (or to the scene root when `new_parent` is `None`).
+    ///
+    /// No-op when `id` does not exist or equals `new_parent`.
+    /// The object's children are carried along unchanged.
+    pub fn reparent(&mut self, id: usize, new_parent: Option<usize>) {
+        if Some(id) == new_parent { return; }
+
+        let old_parent = match self.objects.get(&id) {
+            Some(obj) => obj.parent,
+            None => return,
+        };
+        if old_parent == new_parent { return; }
+
+        // Detach from current location
+        if let Some(p_id) = old_parent {
+            if let Some(p) = self.objects.get_mut(&p_id) {
+                p.children.retain(|&c| c != id);
+            }
+        } else {
+            self.roots.retain(|&r| r != id);
+        }
+
+        // Attach to new location
+        if let Some(p_id) = new_parent {
+            if let Some(p) = self.objects.get_mut(&p_id) {
+                p.children.push(id);
+            }
+        } else {
+            self.roots.push(id);
+        }
+
+        if let Some(obj) = self.objects.get_mut(&id) {
+            obj.parent = new_parent;
+        }
+
+        if let Some(cb) = &mut self.on_scene_graph_modified {
+            (cb.0)(SceneGraphEvent::ObjectReparented { id, old_parent, new_parent });
+        }
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -119,6 +119,26 @@ impl World {
         self.objects.get_mut(&id)
     }
 
+    /// Rename the stable string identifier of a live object and keep the
+    /// internal `name_handles` cache in sync.
+    ///
+    /// **Always prefer this over writing to `object.str_id` directly** when the
+    /// object is already inside a `World`.  Direct field assignment bypasses the
+    /// cache and will silently break every subsequent [`World::get_id`] call for
+    /// the old or new identifier.
+    ///
+    /// Returns `false` (no-op) when `id` does not exist.
+    pub fn rename_str_id(&mut self, id: usize, new_str_id: String) -> bool {
+        if let Some(obj) = self.objects.get_mut(&id) {
+            let old = std::mem::replace(&mut obj.str_id, new_str_id.clone());
+            self.name_handles.remove(&old);
+            self.name_handles.insert(new_str_id, id);
+            true
+        } else {
+            false
+        }
+    }
+
     fn recursive_remove(&mut self, id: usize) {
         // Remove the object and take ownership of its children list
         if let Some(obj) = self.objects.remove(&id) {

--- a/src/world.rs
+++ b/src/world.rs
@@ -69,10 +69,22 @@ impl World {
         let id = self.next_id;
         self.next_id += 1;
 
+        // Validate parent: if the requested parent does not exist, fall back to
+        // root-level placement so the new object is always reachable for
+        // traversal/rendering and the hierarchy stays consistent.
+        let resolved_parent = parent_id.filter(|p_id| self.objects.contains_key(p_id));
+        if parent_id.is_some() && resolved_parent.is_none() {
+            eprintln!(
+                "spawn_object: parent_id {:?} does not exist; spawning '{}' at root instead",
+                parent_id,
+                object.str_id
+            );
+        }
+
         self.name_handles.insert(object.str_id.clone(), id);
-        object.parent = parent_id;
+        object.parent = resolved_parent;
         // If it has a parent, link the child to the parent
-        if let Some(p_id) = parent_id {
+        if let Some(p_id) = resolved_parent {
             if let Some(parent_obj) = self.objects.get_mut(&p_id) {
                 parent_obj.children.push(id);
             }
@@ -84,7 +96,7 @@ impl World {
         self.objects.insert(id, object);
 
         if let Some(cb) = &mut self.on_scene_graph_modified {
-            (cb.0)(SceneGraphEvent::ObjectAdded { id, parent_id });
+            (cb.0)(SceneGraphEvent::ObjectAdded { id, parent_id: resolved_parent });
         }
         id
     }

--- a/src/world.rs
+++ b/src/world.rs
@@ -130,40 +130,85 @@ impl World {
     }
 
     pub fn delete(&mut self, id: usize) {
-        let existed = if let Some(obj) = self.objects.remove(&id) {
-            self.name_handles.remove(&obj.str_id);
-            if let Some(p_id) = obj.parent {
-                if let Some(parent) = self.objects.get_mut(&p_id) {
-                    parent.children.retain(|&child_id| child_id != id);
-                }
-            } else {
-                self.roots.retain(|&root_id| root_id != id);
-            }
-            true
-        } else {
-            false
+        // Remove the root object first so we can read its children list and
+        // parent link before they disappear.
+        let obj = match self.objects.remove(&id) {
+            Some(o) => o,
+            None    => return,   // nothing to do; fire no event
         };
-        self.recursive_remove(id);
 
-        if existed {
-            if let Some(cb) = &mut self.on_scene_graph_modified {
-                (cb.0)(SceneGraphEvent::ObjectDeleted { id });
+        self.name_handles.remove(&obj.str_id);
+
+        // Unlink from parent / root list
+        if let Some(p_id) = obj.parent {
+            if let Some(parent) = self.objects.get_mut(&p_id) {
+                parent.children.retain(|&c| c != id);
+            }
+        } else {
+            self.roots.retain(|&r| r != id);
+        }
+
+        // Recursively destroy all descendants (they were already children of `id`)
+        for child_id in obj.children {
+            self.recursive_remove(child_id);
+        }
+
+        if let Some(cb) = &mut self.on_scene_graph_modified {
+            (cb.0)(SceneGraphEvent::ObjectDeleted { id });
+        }
+    }
+
+    /// Returns `true` when `ancestor` is `node` itself or any ancestor of `node`
+    /// in `node`'s subtree — i.e. when making `ancestor` a child of `node` would
+    /// create a cycle.
+    ///
+    /// Walks *down* from `node` through children, so the name "is_in_subtree"
+    /// means "`candidate` appears somewhere inside the subtree rooted at `node`".
+    fn is_in_subtree(&self, node: usize, candidate: usize) -> bool {
+        if node == candidate { return true; }
+        if let Some(obj) = self.objects.get(&node) {
+            for &child in &obj.children {
+                if self.is_in_subtree(child, candidate) {
+                    return true;
+                }
             }
         }
+        false
     }
 
     /// Move `id` to a new parent (or to the scene root when `new_parent` is `None`).
     ///
-    /// No-op when `id` does not exist or equals `new_parent`.
+    /// # No-op conditions
+    /// - `id` does not exist in the world.
+    /// - `new_parent` is the same as the current parent.
+    /// - `new_parent == Some(id)` (self-parenting).
+    /// - `new_parent` does not exist in the world (guards against dangling links).
+    /// - `new_parent` is a descendant of `id` (would create a cycle).
+    ///
     /// The object's children are carried along unchanged.
-    pub fn reparent(&mut self, id: usize, new_parent: Option<usize>) {
-        if Some(id) == new_parent { return; }
+    pub fn reparent(&mut self, id: usize, new_parent: Option<usize>) -> bool {
+        // Self-parenting
+        if Some(id) == new_parent { return false; }
 
+        // Object must exist
         let old_parent = match self.objects.get(&id) {
             Some(obj) => obj.parent,
-            None => return,
+            None => return false,
         };
-        if old_parent == new_parent { return; }
+
+        // Already there
+        if old_parent == new_parent { return false; }
+
+        // Target parent must exist (unless moving to root)
+        if let Some(p_id) = new_parent {
+            if !self.objects.contains_key(&p_id) { return false; }
+        }
+
+        // Cycle guard: new_parent must not be inside id's subtree
+        // TODO: Instead of failing, we can instead switch the position of those objects
+        if let Some(p_id) = new_parent {
+            if self.is_in_subtree(id, p_id) { return false; }
+        }
 
         // Detach from current location
         if let Some(p_id) = old_parent {
@@ -190,5 +235,6 @@ impl World {
         if let Some(cb) = &mut self.on_scene_graph_modified {
             (cb.0)(SceneGraphEvent::ObjectReparented { id, old_parent, new_parent });
         }
+        true
     }
 }


### PR DESCRIPTION
This pull request adds comprehensive support for scene graph structural change events in the engine, allowing JavaScript and Rust code to react to object additions, deletions, and reparenting in real time. It introduces a new callback system, integrates it into the `World` and `WebWindow` APIs, and provides thorough unit tests to ensure correct event firing and payloads.

**Scene Graph Event System:**

* Introduced the `SceneGraphEvent` enum and `SceneGraphCallback` type in `src/world.rs` to represent and handle structural changes (object added, deleted, or reparented) in the scene hierarchy. The `World` struct now has an `on_scene_graph_modified` callback field, which is invoked after every relevant mutation. [[1]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7R4-R33) [[2]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7R43) [[3]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7L40-R65) [[4]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7R85-R88) [[5]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7L104-R192)

* Implemented the `reparent` method on `World`, enabling moving objects to new parents (or the root), with correct updates to parent/child relationships and event firing. [[1]](diffhunk://#diff-e6dd259bfdeeca4e2cbfd0644f1b4798b16642266a8ee788775ccbd62878aea7L104-R192) [[2]](diffhunk://#diff-721440ccc0c22025feaa5c566b2fb094667a49bbd1cfd46d4ad2ee86e08e5321R99-R113)

**JavaScript/wasm Bindings:**

* Added a new `on_scene_graph_modified` callback to the `WebWindow` struct and exposed it to JavaScript. Registered this callback so that any scene-graph mutation in the engine triggers the JS handler with a serializable event object. [[1]](diffhunk://#diff-ccf7cb9b7284afba65bcbd0f7ae94e73c575889c6a57cc1280ae238d1807e098R57) [[2]](diffhunk://#diff-ccf7cb9b7284afba65bcbd0f7ae94e73c575889c6a57cc1280ae238d1807e098R76) [[3]](diffhunk://#diff-ccf7cb9b7284afba65bcbd0f7ae94e73c575889c6a57cc1280ae238d1807e098R111-R122) [[4]](diffhunk://#diff-ccf7cb9b7284afba65bcbd0f7ae94e73c575889c6a57cc1280ae238d1807e098L132-R161) [[5]](diffhunk://#diff-ccf7cb9b7284afba65bcbd0f7ae94e73c575889c6a57cc1280ae238d1807e098R381-R384) [[6]](diffhunk://#diff-721440ccc0c22025feaa5c566b2fb094667a49bbd1cfd46d4ad2ee86e08e5321R2-R53)

* Defined the `SceneGraphModifiedEvent` enum (serializable for JS) and logic to bridge engine events to JavaScript callbacks, ensuring event payloads are correctly structured and delivered.

**Testing:**

* Added a new test module `test_scene_graph_events.rs` with unit tests covering all scene graph event scenarios: object addition (with/without parent), deletion, reparenting (to new parent, to root, no-op, non-existent IDs), and correct parent/child list updates. [[1]](diffhunk://#diff-35dd501674c29ffd5ce530e622a8726a658242d3a7fc15c623ad653985ccef46R3) [[2]](diffhunk://#diff-23bef0072cd41d3b2a06fe4d37bd295e19131fd9ff521f64c1e98d376cde21edR1-R188)

These changes provide a robust foundation for editor features and external integrations that depend on real-time awareness of scene structure changes.