### PR TITLE
Add per-object scripting system with attach/detach functionality

### DIFF
--- a/binder/src/lib.rs
+++ b/binder/src/lib.rs
@@ -6,3 +6,4 @@ pub mod world;
 pub mod transform;
 pub mod scene;
 pub mod editor;
+pub mod script;

--- a/binder/src/scene.rs
+++ b/binder/src/scene.rs
@@ -5,6 +5,7 @@ use crate::objects::Object;
 use crate::world::World;
 use crate::camera::Camera;
 use crate::editor::Editor;
+use crate::script::WasmScript;
 
 #[wasm_bindgen(typescript_custom_section)]
 const TS_TEXTURE: &'static str = r#"
@@ -215,5 +216,32 @@ impl Scene {
     /// Returns `true` if a texture has been uploaded under `path_key`.
     pub fn has_texture(&self, path_key: &str) -> bool {
         unsafe { (*self.inner).has_texture(path_key) }
+    }
+    
+    /// Attach a [`JsScript`] to object `id`.
+    ///
+    /// `on_start` will be called on the next frame before `on_update`.
+    /// Replaces any previously attached script.
+    ///
+    /// # Arguments
+    ///
+    /// * `id`     - Integer ID of the target object.
+    /// * `script` - A [`JsScript`] constructed with callback functions.
+    pub fn attach_script(&mut self, id: usize, script: WasmScript) {
+        unsafe {
+            (*self.inner).attach_script(id, script.into_core_script());
+        }
+    }
+
+    /// Detach and drop the script for object `id`.
+    ///
+    /// Returns `true` if a script existed and was removed, `false` otherwise.
+    pub fn detach_script(&mut self, id: usize) -> bool {
+        unsafe { (*self.inner).detach_script(id) }
+    }
+
+    /// Returns `true` when object `id` has a script attached.
+    pub fn has_script(&self, id: usize) -> bool {
+        unsafe { (*self.inner).has_script(id) }
     }
 }

--- a/binder/src/script.rs
+++ b/binder/src/script.rs
@@ -1,0 +1,156 @@
+use wasm_bindgen::prelude::*;
+use js_sys::Function;
+use vertra::world::World as CoreWorld;
+use vertra::script::ObjectScript;
+
+/// A per-object script backed by JavaScript callback functions.
+///
+/// Construct one with [`JsScript::new`], optionally supply
+/// `on_start`, `on_update`, and/or `on_fixed_update` JS functions, then
+/// attach it to an object via [`Scene::attach_script`].
+///
+/// Each callback receives:
+/// - `id: number`   - the integer object ID
+/// - `world: World` - a live handle to the scene world
+/// - `dt?: number`  - elapsed time in seconds (absent in `on_start`)
+///
+/// ```js
+/// const script = new JsScript({
+///   on_start(id, world) {
+///     console.log('started', id);
+///   },
+///   on_update(id, world, dt) {
+///     const obj = world.get_object(id);
+///     if (obj) {
+///       const t = obj.transform;
+///       t.position = [t.position[0], t.position[1] + dt, t.position[2]];
+///       obj.transform = t;
+///     }
+///   },
+/// });
+/// scene.attach_script(myId, script);
+/// ```
+pub struct JsObjectScript {
+    on_start_fn:        Option<Function>,
+    on_update_fn:       Option<Function>,
+    on_fixed_update_fn: Option<Function>,
+}
+
+impl JsObjectScript {
+    pub fn new(
+        on_start_fn:        Option<Function>,
+        on_update_fn:       Option<Function>,
+        on_fixed_update_fn: Option<Function>,
+    ) -> Self {
+        Self { on_start_fn, on_update_fn, on_fixed_update_fn }
+    }
+}
+
+impl ObjectScript for JsObjectScript {
+    fn on_start(&mut self, id: usize, world: &mut CoreWorld) {
+        let Some(f) = &self.on_start_fn else { return; };
+        let world_js = crate::world::World { inner: world as *mut CoreWorld };
+        let world_val = JsValue::from(world_js);
+        let id_val    = JsValue::from(id as u32);
+        let _ = f.call2(&JsValue::UNDEFINED, &id_val, &world_val);
+    }
+
+    fn on_update(&mut self, id: usize, world: &mut CoreWorld, dt: f32) {
+        let Some(f) = &self.on_update_fn else { return; };
+        let world_js = crate::world::World { inner: world as *mut CoreWorld };
+        let world_val = JsValue::from(world_js);
+        let id_val    = JsValue::from(id as u32);
+        let dt_val    = JsValue::from_f64(dt as f64);
+        let _ = f.call3(&JsValue::UNDEFINED, &id_val, &world_val, &dt_val);
+    }
+
+    fn on_fixed_update(&mut self, id: usize, world: &mut CoreWorld, dt: f32) {
+        let Some(f) = &self.on_fixed_update_fn else { return; };
+        let world_js = crate::world::World { inner: world as *mut CoreWorld };
+        let world_val = JsValue::from(world_js);
+        let id_val    = JsValue::from(id as u32);
+        let dt_val    = JsValue::from_f64(dt as f64);
+        let _ = f.call3(&JsValue::UNDEFINED, &id_val, &world_val, &dt_val);
+    }
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_JS_SCRIPT: &'static str = r#"
+/** Callbacks for a per-object [`JsScript`]. */
+export interface JsScriptOptions {
+    /** Called once when the script is first activated. */
+    on_start?: (id: number, world: World) => void;
+    /** Called every frame (variable dt in seconds). */
+    on_update?: (id: number, world: World, dt: number) => void;
+    /** Called at the fixed timestep (~60 Hz, fixed dt in seconds). */
+    on_fixed_update?: (id: number, world: World, dt: number) => void;
+}
+"#;
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_SCENE_SCRIPT_METHODS: &'static str = r#"
+export interface SceneScriptMethods {
+    /**
+     * Attach a script to object `id`.
+     *
+     * Replaces any previously attached script.  `on_start` will be called on
+     * the next frame before `on_update`.
+     */
+    attach_script(id: number, script: JsScript): void;
+    /**
+     * Detach and drop the script for object `id`.
+     *
+     * Returns `true` if a script existed and was removed.
+     */
+    detach_script(id: number): boolean;
+    /** Returns `true` when object `id` has a script attached. */
+    has_script(id: number): boolean;
+}
+"#;
+
+/// A script object that can be attached to a scene object.
+///
+/// Create one with the constructor, supplying up to three callback functions,
+/// then attach it to an object ID via [`Scene::attach_script`].
+#[wasm_bindgen(js_name = JsScript)]
+pub struct WasmScript {
+    #[wasm_bindgen(skip)]
+    pub on_start_fn:        Option<Function>,
+    #[wasm_bindgen(skip)]
+    pub on_update_fn:       Option<Function>,
+    #[wasm_bindgen(skip)]
+    pub on_fixed_update_fn: Option<Function>,
+}
+
+#[wasm_bindgen(js_name = JsScript)]
+impl WasmScript {
+    /// Create a new script from an options object with optional callback fields.
+    ///
+    /// ```js
+    /// const script = new JsScript({
+    ///   on_update(id, world, dt) { /* ... */ },
+    /// });
+    /// ```
+    #[wasm_bindgen(constructor)]
+    pub fn new(options: JsValue) -> Self {
+        let on_start_fn        = js_sys::Reflect::get(&options, &"on_start".into())
+            .ok().and_then(|v| v.dyn_into::<Function>().ok());
+        let on_update_fn       = js_sys::Reflect::get(&options, &"on_update".into())
+            .ok().and_then(|v| v.dyn_into::<Function>().ok());
+        let on_fixed_update_fn = js_sys::Reflect::get(&options, &"on_fixed_update".into())
+            .ok().and_then(|v| v.dyn_into::<Function>().ok());
+        Self { on_start_fn, on_update_fn, on_fixed_update_fn }
+    }
+
+    /// Convert into a boxed `JsObjectScript` suitable for the Rust registry.
+    ///
+    /// Consumes `self` - call this exactly once when passing to `attach_script`.
+    pub(crate) fn into_core_script(self) -> Box<dyn ObjectScript> {
+        Box::new(JsObjectScript::new(
+            self.on_start_fn,
+            self.on_update_fn,
+            self.on_fixed_update_fn,
+        ))
+    }
+}
+

--- a/binder/src/script.rs
+++ b/binder/src/script.rs
@@ -51,26 +51,32 @@ impl ObjectScript for JsObjectScript {
         let Some(f) = &self.on_start_fn else { return; };
         let world_js = crate::world::World { inner: world as *mut CoreWorld };
         let world_val = JsValue::from(world_js);
-        let id_val    = JsValue::from(id as u32);
+        let id_val    = JsValue::from_f64(id as f64);
+        crate::world::script_borrow_enter();
         let _ = f.call2(&JsValue::UNDEFINED, &id_val, &world_val);
+        crate::world::script_borrow_exit();
     }
 
     fn on_update(&mut self, id: usize, world: &mut CoreWorld, dt: f32) {
         let Some(f) = &self.on_update_fn else { return; };
         let world_js = crate::world::World { inner: world as *mut CoreWorld };
         let world_val = JsValue::from(world_js);
-        let id_val    = JsValue::from(id as u32);
+        let id_val    = JsValue::from_f64(id as f64);
         let dt_val    = JsValue::from_f64(dt as f64);
+        crate::world::script_borrow_enter();
         let _ = f.call3(&JsValue::UNDEFINED, &id_val, &world_val, &dt_val);
+        crate::world::script_borrow_exit();
     }
 
     fn on_fixed_update(&mut self, id: usize, world: &mut CoreWorld, dt: f32) {
         let Some(f) = &self.on_fixed_update_fn else { return; };
         let world_js = crate::world::World { inner: world as *mut CoreWorld };
         let world_val = JsValue::from(world_js);
-        let id_val    = JsValue::from(id as u32);
+        let id_val    = JsValue::from_f64(id as f64);
         let dt_val    = JsValue::from_f64(dt as f64);
+        crate::world::script_borrow_enter();
         let _ = f.call3(&JsValue::UNDEFINED, &id_val, &world_val, &dt_val);
+        crate::world::script_borrow_exit();
     }
 }
 

--- a/binder/src/world.rs
+++ b/binder/src/world.rs
@@ -13,6 +13,44 @@ thread_local! {
     /// the same pointer as a second `&mut`.
     static SCENE_GRAPH_QUEUE: std::cell::RefCell<Vec<SceneGraphModifiedEvent>> =
         std::cell::RefCell::new(Vec::new());
+    /// Set to `true` for the duration of a JS script callback.
+    ///
+    /// Any World WASM method that takes `&mut self` checks this flag and throws
+    /// a JS TypeError if it is set, preventing a JS script from creating a
+    /// second aliased `&mut CoreWorld` through the raw pointer while the Rust
+    /// borrow is still alive.
+    static SCRIPT_BORROW_ACTIVE: std::cell::Cell<bool> =
+        std::cell::Cell::new(false);
+}
+
+/// Mark the start of a JS script callback.  Call [`script_borrow_exit`] in
+/// every code path that follows (including after a JS exception is caught).
+pub(crate) fn script_borrow_enter() {
+    SCRIPT_BORROW_ACTIVE.with(|c| c.set(true));
+}
+
+/// Mark the end of a JS script callback, re-enabling world mutations.
+pub(crate) fn script_borrow_exit() {
+    SCRIPT_BORROW_ACTIVE.with(|c| c.set(false));
+}
+
+/// Throw a JS TypeError when called re-entrantly during a script callback.
+///
+/// Inserted at the top of every `&mut self` World WASM method so that a JS
+/// script cannot create a second aliased `&mut CoreWorld` while the Rust
+/// callback still holds the first one.
+#[inline]
+fn guard_no_script_borrow() {
+    // TODO: this is a bit of a blunt instrument, it prevents *any* world mutation
+    if SCRIPT_BORROW_ACTIVE.with(|c| c.get()) {
+        wasm_bindgen::throw_str(
+            "World mutation (spawn_object / delete / reparent / rename_str_id) \
+             is not allowed inside an on_start / on_update / on_fixed_update \
+             script callback because Rust already holds an exclusive borrow of \
+             the world at that point.  Enqueue mutations and apply them after \
+             the callback returns instead."
+        );
+    }
 }
 
 /// Register (or clear) the JS function that receives scene-graph change events.
@@ -100,6 +138,7 @@ impl World {
     ///
     /// The unique integer ID assigned to the new object instance.
     pub fn spawn_object(&mut self, object: &Object, parent_id: Option<usize>) -> usize {
+        guard_no_script_borrow();
         let id = unsafe {
             (*self.inner).spawn_object((*object.inner).clone(), parent_id)
         };
@@ -117,6 +156,7 @@ impl World {
     ///
     /// * `id` - The unique integer ID of the root object to remove.
     pub fn delete(&mut self, id: usize) {
+        guard_no_script_borrow();
         unsafe {
             (*self.inner).delete(id);
         }
@@ -145,6 +185,7 @@ impl World {
     ///
     /// `true` if the reparent was applied; `false` if it was rejected.
     pub fn reparent(&mut self, id: usize, new_parent_id: Option<usize>) -> bool {
+        guard_no_script_borrow();
         let result = unsafe {
             (*self.inner).reparent(id, new_parent_id)
         };
@@ -223,6 +264,7 @@ impl World {
     ///
     /// `true` if the rename succeeded; `false` when `id` does not exist.
     pub fn rename_str_id(&mut self, id: usize, new_str_id: String) -> bool {
+        guard_no_script_borrow();
         unsafe {
             (*self.inner).rename_str_id(id, new_str_id)
         }

--- a/examples/scripted_objects.rs
+++ b/examples/scripted_objects.rs
@@ -1,0 +1,305 @@
+//! # scripted_objects
+//!
+//! Demonstrates the **per-object script** system.
+//!
+//! Five objects are spawned, each with a different script showing a different
+//! aspect of the API:
+//!
+//! | Object            | Script            | What it does                                        |
+//! |-------------------|-------------------|-----------------------------------------------------|
+//! | Spinning cube     | `RotateY`         | Y-rotation every `on_update`                        |
+//! | Bobbing sphere    | `BobY`            | Sine-wave Y translation using internal phase state  |
+//! | Pulse sphere      | `PulseScale`      | Uniform scale pulses via `on_fixed_update`          |
+//! | Color-cycle plane | `ColorCycle`      | Hue-cycles RGBA color each frame                    |
+//! | Logger cube       | `StartLogger`     | Prints once in `on_start`, then silently continues  |
+//!
+//! Press **Escape** to toggle between editor mode and play mode.
+//! Scripts only run during **play mode**.
+//!
+//! Run with:
+//! ```
+//! cargo run --example scripted_objects
+//! ```
+
+use std::collections::HashSet;
+use vertra::camera::Camera;
+use vertra::geometry::Geometry;
+use vertra::objects::Object;
+use vertra::scene::Scene;
+use vertra::script::ObjectScript;
+use vertra::transform::Transform;
+use vertra::window::{FrameContext, Window};
+use vertra::world::World;
+use vertra::event::{Event, WindowEvent, DeviceEvent, ElementState};
+use winit::keyboard::{KeyCode, PhysicalKey};
+
+/// Continuously rotates an object around the Y axis.
+struct RotateY {
+    /// Rotation speed in degrees per second.
+    speed_deg: f32,
+}
+
+impl ObjectScript for RotateY {
+    fn on_update(&mut self, id: usize, world: &mut World, dt: f32) {
+        if let Some(obj) = world.get_mut(id) {
+            obj.transform.rotation[1] += self.speed_deg * dt;
+        }
+    }
+}
+
+/// Moves an object up and down using a sine wave.
+struct BobY {
+    /// Amplitude of the sine wave in world units.
+    amplitude: f32,
+    /// Oscillation frequency in Hz.
+    frequency: f32,
+    /// Accumulated time used as phase input.
+    time: f32,
+    /// Y position at spawn time — restored each frame to avoid drift.
+    base_y: f32,
+}
+
+impl BobY {
+    fn new(amplitude: f32, frequency: f32) -> Self {
+        Self { amplitude, frequency, time: 0.0, base_y: 0.0 }
+    }
+}
+
+impl ObjectScript for BobY {
+    fn on_start(&mut self, id: usize, world: &mut World) {
+        // Capture the object's initial Y so we oscillate around it.
+        if let Some(obj) = world.get_mut(id) {
+            self.base_y = obj.transform.position[1];
+        }
+        println!("[BobY] on_start for id={id}, base_y={}", self.base_y);
+    }
+
+    fn on_update(&mut self, id: usize, world: &mut World, dt: f32) {
+        self.time += dt;
+        let offset = self.amplitude * (self.time * self.frequency * std::f32::consts::TAU).sin();
+        if let Some(obj) = world.get_mut(id) {
+            obj.transform.position[1] = self.base_y + offset;
+        }
+    }
+}
+
+/// Pulses the uniform scale of an object in sync with the fixed timestep.
+struct PulseScale {
+    /// Base scale (resting size).
+    base_scale: f32,
+    /// Half-amplitude of the pulse.
+    amplitude: f32,
+    /// Oscillation frequency in Hz.
+    frequency: f32,
+    /// Accumulated fixed-step time.
+    time: f32,
+}
+
+impl PulseScale {
+    fn new(base_scale: f32, amplitude: f32, frequency: f32) -> Self {
+        Self { base_scale, amplitude, frequency, time: 0.0 }
+    }
+}
+
+impl ObjectScript for PulseScale {
+    fn on_fixed_update(&mut self, id: usize, world: &mut World, dt: f32) {
+        self.time += dt;
+        let s = self.base_scale
+            + self.amplitude * (self.time * self.frequency * std::f32::consts::TAU).sin();
+        if let Some(obj) = world.get_mut(id) {
+            obj.transform.scale = [s, s, s];
+        }
+    }
+}
+
+/// Cycles the RGBA colour of an object through the hue spectrum.
+struct ColorCycle {
+    /// Current hue in [0.0, 1.0).
+    hue: f32,
+    /// Hue advance per second.
+    speed: f32,
+}
+
+impl ColorCycle {
+    fn new(speed: f32) -> Self {
+        Self { hue: 0.0, speed }
+    }
+}
+
+/// Converts a hue (0–1) to an RGB triple using the classic 6-sector formula.
+fn hue_to_rgb(h: f32) -> [f32; 3] {
+    let h6 = h * 6.0;
+    let i  = h6 as u32;
+    let f  = h6 - i as f32;
+    match i % 6 {
+        0 => [1.0, f,   0.0],
+        1 => [1.0 - f, 1.0, 0.0],
+        2 => [0.0, 1.0, f  ],
+        3 => [0.0, 1.0 - f, 1.0],
+        4 => [f,   0.0, 1.0],
+        _ => [1.0, 0.0, 1.0 - f],
+    }
+}
+
+impl ObjectScript for ColorCycle {
+    fn on_update(&mut self, id: usize, world: &mut World, dt: f32) {
+        self.hue = (self.hue + self.speed * dt).fract();
+        let [r, g, b] = hue_to_rgb(self.hue);
+        if let Some(obj) = world.get_mut(id) {
+            obj.color = [r, g, b, 1.0];
+        }
+    }
+}
+
+/// Prints a message in `on_start`, then does nothing else.
+/// Useful for verifying that `on_start` fires exactly once.
+struct StartLogger {
+    label: String,
+}
+
+impl ObjectScript for StartLogger {
+    fn on_start(&mut self, id: usize, _world: &mut World) {
+        println!("[StartLogger] \"{}\" (id={id}) — on_start fired!", self.label);
+    }
+}
+
+struct AppState {
+    keys: HashSet<KeyCode>,
+}
+
+fn main() {
+    Window::new(AppState { keys: HashSet::new() })
+        .with_title("Scripted Objects")
+        .with_camera(
+            Camera::new()
+                .with_position([0.0, 4.0, -14.0])
+                .with_rotation(90.0, -15.0),
+        )
+        .on_startup(|_state, scene, _ctx| {
+            spawn_scene(scene);
+            scene.enable_editor_mode();
+        })
+        .on_update(|state, scene, ctx| {
+            if scene.editor.is_none() {
+                scene.camera.handle_default_input(&state.keys, 6.0, ctx);
+            }
+        })
+        .with_event_handler(|state, scene, event, _| {
+            handle_input(state, scene, event);
+        })
+        .create();
+}
+
+fn spawn_scene(scene: &mut Scene) {
+    // 1. Spinning cube (RotateY)
+    let cube_id = scene.spawn(
+        Object {
+            name:     "SpinningCube".into(),
+            str_id:   "spin_cube".into(),
+            transform: Transform::from_position(-6.0, 0.0, 0.0),
+            geometry: Some(Geometry::Cube { size: 1.5 }),
+            color:    [0.9, 0.3, 0.2, 1.0],
+            ..Default::default()
+        },
+        None,
+    );
+    scene.attach_script(cube_id, Box::new(RotateY { speed_deg: 90.0 }));
+
+    // 2. Bobbing sphere (BobY)
+    let bob_id = scene.spawn(
+        Object {
+            name:     "BobbingSphere".into(),
+            str_id:   "bob_sphere".into(),
+            transform: Transform::from_position(-2.0, 0.0, 0.0),
+            geometry: Some(Geometry::Sphere { radius: 0.8, subdivisions: 20 }),
+            color:    [0.2, 0.8, 0.3, 1.0],
+            ..Default::default()
+        },
+        None,
+    );
+    scene.attach_script(bob_id, Box::new(BobY::new(1.5, 0.8)));
+
+    // 3. Pulsing sphere (PulseScale via on_fixed_update)
+    let pulse_id = scene.spawn(
+        Object {
+            name:     "PulseSphere".into(),
+            str_id:   "pulse_sphere".into(),
+            transform: Transform::from_position(2.0, 0.0, 0.0),
+            geometry: Some(Geometry::Sphere { radius: 0.8, subdivisions: 20 }),
+            color:    [0.3, 0.5, 1.0, 1.0],
+            ..Default::default()
+        },
+        None,
+    );
+    scene.attach_script(pulse_id, Box::new(PulseScale::new(1.0, 0.4, 1.5)));
+
+    // 4. Color-cycling plane (ColorCycle)
+    let plane_id = scene.spawn(
+        Object {
+            name:     "ColorPlane".into(),
+            str_id:   "color_plane".into(),
+            transform: Transform::from_position(6.0, 0.0, 0.0),
+            geometry: Some(Geometry::Plane { size: 2.0 }),
+            color:    [1.0, 1.0, 1.0, 1.0],
+            ..Default::default()
+        },
+        None,
+    );
+    scene.attach_script(plane_id, Box::new(ColorCycle::new(0.4)));
+
+    // 5. Logger cube (StartLogger)
+    //    Spawned as a child of the spinning cube so it orbits around it.
+    let logger_id = scene.spawn(
+        Object {
+            name:     "LoggerCube".into(),
+            str_id:   "logger_cube".into(),
+            transform: Transform::from_position(2.5, 0.0, 0.0),
+            geometry: Some(Geometry::Cube { size: 0.5 }),
+            color:    [1.0, 1.0, 0.2, 1.0],
+            ..Default::default()
+        },
+        Some(cube_id),
+    );
+    scene.attach_script(logger_id, Box::new(StartLogger { label: "LoggerCube".into() }));
+
+    println!(
+        "[startup] Spawned {} objects with scripts.",
+        scene.world.objects.len()
+    );
+}
+
+fn handle_input(state: &mut AppState, scene: &mut vertra::scene::Scene, event: Event<()>) {
+    match event {
+        Event::DeviceEvent {
+            event: DeviceEvent::MouseMotion { delta: (dx, dy) }, ..
+        } => {
+            if scene.editor.is_none() {
+                scene.camera.rotate(dx as f32 * 0.15, dy as f32 * 0.15, false);
+            }
+        }
+        Event::WindowEvent {
+            event: WindowEvent::KeyboardInput { event: ke, .. }, ..
+        } => {
+            if let PhysicalKey::Code(code) = ke.physical_key {
+                if scene.editor.is_none() {
+                    match ke.state {
+                        ElementState::Pressed  => { state.keys.insert(code); }
+                        ElementState::Released => { state.keys.remove(&code); }
+                    }
+                } else {
+                    state.keys.clear();
+                }
+
+                if code == KeyCode::Escape && ke.state == ElementState::Pressed {
+                    if scene.editor.is_some() {
+                        scene.disable_editor_mode();
+                    } else {
+                        scene.enable_editor_mode();
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod constants;
 pub mod world;
 pub mod objects;
 pub mod editor;
+pub mod script;
 
 #[cfg(test)]
 mod tests;

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -214,6 +214,11 @@ impl Scene {
             Err(e) => eprintln!("disable_editor_mode: failed to capture snapshot: {e}"),
         }
         self.editor = None;
+        // Reset all scripts so on_start re-runs against the fresh world that
+        // will be restored when the user returns to editor mode.  Without this,
+        // cached IDs / base transforms from a previous play session would be
+        // stale after the snapshot is restored.
+        self.script_registry.reset_started();
     }
 
     /// Feed a platform-agnostic [`EditorEvent`] into the editor.
@@ -311,6 +316,9 @@ impl Scene {
         let data = vtr::read_from_file(path)?;
         self.camera = data.camera;
         self.world  = data.world;
+        // World has changed, cached script state (IDs, transforms, etc.) is
+        // no longer valid for the new world, so force on_start to re-run.
+        self.script_registry.reset_started();
         Ok(())
     }
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -7,6 +7,7 @@ use crate::world::World;
 use crate::objects::Object;
 use crate::transform::Transform;
 use crate::vtr::{self, VtrError};
+use crate::script::{ObjectScript, ScriptRegistry};
 
 /// A loaded GPU texture paired with its bind group.
 ///
@@ -51,6 +52,9 @@ pub struct Scene {
     /// any mutations that occurred during play (object movement, etc.) are
     /// reverted to the exact state the editor saved.
     pub(crate) snapshot: Option<Vec<u8>>,
+    /// Per-object script registry.  Kept separate from `World` so scripts
+    /// never affect serialisation.
+    pub script_registry: ScriptRegistry,
 }
 
 impl Scene {
@@ -242,6 +246,47 @@ impl Scene {
     /// or `None` if nothing is selected or editor mode is inactive.
     pub fn inspector(&self) -> Option<&InspectorData> {
         self.editor.as_ref()?.inspector.selected.as_ref()
+    }
+    
+    /// Attach `script` to object `id`.
+    ///
+    /// The script's [`ObjectScript::on_start`] will be called on the next
+    /// `run_scripts` / `run_fixed_update_scripts` invocation before
+    /// [`ObjectScript::on_update`] / [`ObjectScript::on_fixed_update`].
+    ///
+    /// If the object already had a script it is replaced.  Scripts are
+    /// suppressed while editor mode is active, i.e. the window loop does not call
+    /// `run_scripts` when `scene.editor.is_some()`.
+    pub fn attach_script(&mut self, id: usize, script: Box<dyn ObjectScript>) {
+        self.script_registry.attach(id, script);
+    }
+
+    /// Detach and drop the script for object `id`.
+    ///
+    /// Returns `true` if a script existed and was removed.
+    pub fn detach_script(&mut self, id: usize) -> bool {
+        self.script_registry.detach(id)
+    }
+
+    /// Returns `true` when object `id` has a script attached.
+    pub fn has_script(&self, id: usize) -> bool {
+        self.script_registry.has(id)
+    }
+
+    /// Run `on_start` (first call only) + `on_update` for all attached scripts.
+    ///
+    /// Called automatically by the window loop every frame when not in editor
+    /// mode.  You do not normally need to call this manually.
+    pub fn run_scripts(&mut self, dt: f32) {
+        self.script_registry.run_update(&mut self.world, dt);
+    }
+
+    /// Run `on_start` (first call only) + `on_fixed_update` for all attached scripts.
+    ///
+    /// Called automatically by the window loop at the fixed timestep when not
+    /// in editor mode.  You do not normally need to call this manually.
+    pub fn run_fixed_update_scripts(&mut self, dt: f32) {
+        self.script_registry.run_fixed_update(&mut self.world, dt);
     }
 
     /// Serialize the current camera and world to a `.vtr` binary file.

--- a/src/script.rs
+++ b/src/script.rs
@@ -1,0 +1,158 @@
+/// Per-object behaviour callbacks.
+///
+/// Implement this trait to attach custom logic to any scene object.
+/// The runtime calls each method at the appropriate point in the frame
+/// loop **only while editor mode is inactive** (same suppression rule as
+/// [`crate::window::Window::on_update`]).
+///
+/// # Efficiency
+///
+/// Scripts are stored in a [`ScriptRegistry`] that is kept entirely
+/// separate from the serialisable [`crate::world::World`].  When no
+/// scripts are attached the hot paths in the window loop are zero-cost:
+/// the empty-check short-circuits before any iteration.  When scripts
+/// *are* present the registry temporarily moves its `Vec` out of
+/// `self` (an O(1) pointer swap) so that the script closures can hold
+/// an exclusive reference to the world simultaneously, with no heap
+/// allocation per frame.
+pub trait ObjectScript: 'static {
+    /// Called once the first time the registry runs its update pass after
+    /// the script was attached.  Use it to pre-resolve string IDs into
+    /// integer IDs and to initialise per-object state.
+    fn on_start(&mut self, id: usize, world: &mut crate::world::World) {
+        let _ = (id, world);
+    }
+
+    /// Called every frame before rendering (variable delta-time).
+    ///
+    /// `dt` is elapsed time in seconds since the previous frame.
+    fn on_update(&mut self, id: usize, world: &mut crate::world::World, dt: f32) {
+        let _ = (id, world, dt);
+    }
+
+    /// Called at the fixed timestep (default 60 Hz, independent of frame rate).
+    ///
+    /// `dt` is the fixed timestep duration in seconds
+    /// ([`crate::constants::window::FIXED_DELTA`]).
+    fn on_fixed_update(&mut self, id: usize, world: &mut crate::world::World, dt: f32) {
+        let _ = (id, world, dt);
+    }
+}
+
+struct ScriptEntry {
+    id:      usize,
+    script:  Box<dyn ObjectScript>,
+    started: bool,
+}
+
+/// Per-scene registry that maps object IDs to their [`ObjectScript`]
+/// implementations.
+///
+/// Stored in [`crate::scene::Scene`] (not in `World`) so scripts never
+/// interfere with scene serialisation.
+///
+/// # Thread safety
+///
+/// `ScriptRegistry` is `!Send` / `!Sync` because trait objects are
+/// heap-allocated with `Box<dyn ObjectScript>`.  This matches the rest of
+/// the engine which is single-threaded.
+#[derive(Default)]
+pub struct ScriptRegistry {
+    /// Flat storage – optimised for iteration (hot path).
+    entries: Vec<ScriptEntry>,
+    /// Index map for O(1) attach / detach lookups.
+    index:   std::collections::HashMap<usize, usize>,
+}
+
+impl ScriptRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+    
+    /// Attach `script` to object `id`.
+    ///
+    /// If a script is already attached to `id` it is replaced.  `on_start`
+    /// will be called for the new script on the next update pass.
+    pub fn attach(&mut self, id: usize, script: Box<dyn ObjectScript>) {
+        if let Some(&idx) = self.index.get(&id) {
+            // Replace in-place; reset started flag so on_start runs again.
+            self.entries[idx].script  = script;
+            self.entries[idx].started = false;
+        } else {
+            let idx = self.entries.len();
+            self.entries.push(ScriptEntry { id, script, started: false });
+            self.index.insert(id, idx);
+        }
+    }
+
+    /// Detach and drop the script for object `id`.
+    ///
+    /// Returns `true` if a script existed, `false` if `id` had no script.
+    pub fn detach(&mut self, id: usize) -> bool {
+        let Some(idx) = self.index.remove(&id) else { return false; };
+
+        // swap_remove is O(1), swap last element into this slot.
+        let last_idx = self.entries.len() - 1;
+        if idx != last_idx {
+            self.entries.swap(idx, last_idx);
+            // Update the moved element's index entry.
+            let moved_id = self.entries[idx].id;
+            self.index.insert(moved_id, idx);
+        }
+        self.entries.pop();
+        true
+    }
+
+    /// Returns `true` when object `id` has an attached script.
+    pub fn has(&self, id: usize) -> bool {
+        self.index.contains_key(&id)
+    }
+
+    /// Number of scripts currently registered.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// `true` when no scripts are registered.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+    
+    /// Run `on_start` (if needed) + `on_update` for every registered script.
+    ///
+    /// Internally the entry `Vec` is temporarily *moved out* of `self` via
+    /// `std::mem::take` (an O(1) pointer swap, zero allocation) so that both
+    /// the script and the `&mut World` borrow can be alive concurrently.
+    /// After iteration the `Vec` is moved back.
+    pub(crate) fn run_update(&mut self, world: &mut crate::world::World, dt: f32) {
+        if self.entries.is_empty() { return; }
+
+        let mut entries = std::mem::take(&mut self.entries);
+        for entry in &mut entries {
+            if !entry.started {
+                entry.script.on_start(entry.id, world);
+                entry.started = true;
+            }
+            entry.script.on_update(entry.id, world, dt);
+        }
+        self.entries = entries;
+    }
+
+    /// Run `on_start` (if needed) + `on_fixed_update` for every registered
+    /// script.
+    pub(crate) fn run_fixed_update(&mut self, world: &mut crate::world::World, dt: f32) {
+        if self.entries.is_empty() { return; }
+
+        let mut entries = std::mem::take(&mut self.entries);
+        for entry in &mut entries {
+            if !entry.started {
+                entry.script.on_start(entry.id, world);
+                entry.started = true;
+            }
+            entry.script.on_fixed_update(entry.id, world, dt);
+        }
+        self.entries = entries;
+    }
+}
+

--- a/src/script.rs
+++ b/src/script.rs
@@ -11,10 +11,9 @@
 /// separate from the serialisable [`crate::world::World`].  When no
 /// scripts are attached the hot paths in the window loop are zero-cost:
 /// the empty-check short-circuits before any iteration.  When scripts
-/// *are* present the registry temporarily moves its `Vec` out of
-/// `self` (an O(1) pointer swap) so that the script closures can hold
-/// an exclusive reference to the world simultaneously, with no heap
-/// allocation per frame.
+/// *are* present the registry iterates `self.entries` in-place, `world`
+/// is a separate parameter so both borrows coexist with no heap allocation
+/// per frame and no inconsistent state if a callback panics.
 pub trait ObjectScript: 'static {
     /// Called once the first time the registry runs its update pass after
     /// the script was attached.  Use it to pre-resolve string IDs into
@@ -52,13 +51,13 @@ struct ScriptEntry {
 /// interfere with scene serialisation.
 ///
 /// # Thread safety
-///
-/// `ScriptRegistry` is `!Send` / `!Sync` because trait objects are
-/// heap-allocated with `Box<dyn ObjectScript>`.  This matches the rest of
-/// the engine which is single-threaded.
+/// `ScriptRegistry` is `!Send` / `!Sync` because it stores
+/// `Box<dyn ObjectScript>`, and `dyn ObjectScript` does not require the
+/// `Send` / `Sync` auto-trait bounds. This matches the rest of the engine
+/// which is single-threaded.
 #[derive(Default)]
 pub struct ScriptRegistry {
-    /// Flat storage – optimised for iteration (hot path).
+    /// Flat storage, optimised for iteration (hot path).
     entries: Vec<ScriptEntry>,
     /// Index map for O(1) attach / detach lookups.
     index:   std::collections::HashMap<usize, usize>,
@@ -119,40 +118,84 @@ impl ScriptRegistry {
         self.entries.is_empty()
     }
     
+    /// Reset every script's `started` flag so `on_start` is re-invoked on the
+    /// next update pass.
+    ///
+    /// Call this whenever the world is restored from a snapshot (e.g. when
+    /// entering play mode after editor mode) so that cached IDs and
+    /// per-script state are re-initialised against the fresh world.
+    pub fn reset_started(&mut self) {
+        for entry in &mut self.entries {
+            entry.started = false;
+        }
+    }
+
     /// Run `on_start` (if needed) + `on_update` for every registered script.
     ///
-    /// Internally the entry `Vec` is temporarily *moved out* of `self` via
-    /// `std::mem::take` (an O(1) pointer swap, zero allocation) so that both
-    /// the script and the `&mut World` borrow can be alive concurrently.
-    /// After iteration the `Vec` is moved back.
+    /// Stale entries whose object ID no longer exists in `world` are pruned
+    /// lazily (O(1) swap-remove per stale entry).
+    ///
+    /// Iterates `self.entries` directly — no heap allocation, and registry
+    /// invariants are preserved even if a script callback panics.
     pub(crate) fn run_update(&mut self, world: &mut crate::world::World, dt: f32) {
         if self.entries.is_empty() { return; }
 
-        let mut entries = std::mem::take(&mut self.entries);
-        for entry in &mut entries {
-            if !entry.started {
-                entry.script.on_start(entry.id, world);
-                entry.started = true;
+        let mut i = 0;
+        while i < self.entries.len() {
+            let id = self.entries[i].id;
+            if !world.objects.contains_key(&id) {
+                self.prune_at(i);
+                // Do NOT advance i: the swap moved an unvisited entry here.
+            } else {
+                {
+                    let entry = &mut self.entries[i];
+                    if !entry.started {
+                        entry.script.on_start(id, world);
+                        entry.started = true;
+                    }
+                    entry.script.on_update(id, world, dt);
+                }
+                i += 1;
             }
-            entry.script.on_update(entry.id, world, dt);
         }
-        self.entries = entries;
     }
 
     /// Run `on_start` (if needed) + `on_fixed_update` for every registered
     /// script.
+    ///
+    /// Same pruning and panic-safety guarantees as [`run_update`].
     pub(crate) fn run_fixed_update(&mut self, world: &mut crate::world::World, dt: f32) {
         if self.entries.is_empty() { return; }
 
-        let mut entries = std::mem::take(&mut self.entries);
-        for entry in &mut entries {
-            if !entry.started {
-                entry.script.on_start(entry.id, world);
-                entry.started = true;
+        let mut i = 0;
+        while i < self.entries.len() {
+            let id = self.entries[i].id;
+            if !world.objects.contains_key(&id) {
+                self.prune_at(i);
+            } else {
+                {
+                    let entry = &mut self.entries[i];
+                    if !entry.started {
+                        entry.script.on_start(id, world);
+                        entry.started = true;
+                    }
+                    entry.script.on_fixed_update(id, world, dt);
+                }
+                i += 1;
             }
-            entry.script.on_fixed_update(entry.id, world, dt);
         }
-        self.entries = entries;
+    }
+
+    /// O(1) swap-remove at index `i`, keeping `self.index` consistent.
+    fn prune_at(&mut self, i: usize) {
+        let id = self.entries[i].id;
+        self.index.remove(&id);
+        let last = self.entries.len() - 1;
+        if i != last {
+            self.entries.swap(i, last);
+            let moved_id = self.entries[i].id;
+            self.index.insert(moved_id, i);
+        }
+        self.entries.pop();
     }
 }
-

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,3 +2,4 @@ mod test_timer;
 mod test_vtr;
 mod test_scene_graph_events;
 mod test_snapshot;
+mod test_scripts;

--- a/src/tests/test_scripts.rs
+++ b/src/tests/test_scripts.rs
@@ -1,0 +1,314 @@
+//! Unit tests for the per-object script system.
+//!
+//! These tests exercise:
+//! - attach / detach lifecycle
+//! - `on_start` called exactly once
+//! - `on_update` and `on_fixed_update` receiving correct IDs and dt
+//! - world mutations performed inside scripts
+//! - replacing a script resets `on_start`
+//! - detaching a non-existent script is a no-op
+//! - empty registry is zero-cost (no panic, no iteration)
+//! - multiple scripts run independently
+
+use crate::objects::Object;
+use crate::world::World;
+use crate::script::{ObjectScript, ScriptRegistry};
+
+fn make_world_with_object() -> (World, usize) {
+    let mut world = World::new();
+    let obj = Object {
+        name: "test".into(),
+        str_id: "test_obj".into(),
+        ..Default::default()
+    };
+    let id = world.spawn_object(obj, None);
+    (world, id)
+}
+
+struct CounterScript {
+    start_count:  usize,
+    update_count: usize,
+    fixed_count:  usize,
+    last_dt:      f32,
+    last_id:      usize,
+}
+
+impl CounterScript {
+    fn new() -> Self {
+        Self { start_count: 0, update_count: 0, fixed_count: 0, last_dt: 0.0, last_id: usize::MAX }
+    }
+}
+
+impl ObjectScript for CounterScript {
+    fn on_start(&mut self, id: usize, _world: &mut World) {
+        self.start_count  += 1;
+        self.last_id       = id;
+    }
+    fn on_update(&mut self, id: usize, _world: &mut World, dt: f32) {
+        self.update_count += 1;
+        self.last_dt       = dt;
+        self.last_id       = id;
+    }
+    fn on_fixed_update(&mut self, id: usize, _world: &mut World, dt: f32) {
+        self.fixed_count  += 1;
+        self.last_dt       = dt;
+        self.last_id       = id;
+    }
+}
+
+#[test]
+fn attach_and_has_script() {
+    let (mut world, id) = make_world_with_object();
+    let mut reg = ScriptRegistry::new();
+
+    assert!(!reg.has(id));
+    reg.attach(id, Box::new(CounterScript::new()));
+    assert!(reg.has(id));
+    assert_eq!(reg.len(), 1);
+
+    // Running update to satisfy borrow
+    reg.run_update(&mut world, 0.0);
+}
+
+#[test]
+fn detach_removes_script() {
+    let (mut _world, id) = make_world_with_object();
+    let mut reg = ScriptRegistry::new();
+
+    reg.attach(id, Box::new(CounterScript::new()));
+    assert!(reg.detach(id));
+    assert!(!reg.has(id));
+    assert!(reg.is_empty());
+}
+
+#[test]
+fn detach_nonexistent_returns_false() {
+    let mut reg = ScriptRegistry::new();
+    assert!(!reg.detach(999));
+}
+
+#[test]
+fn on_start_called_exactly_once_on_first_update() {
+    let (mut world, id) = make_world_with_object();
+    let script = Box::new(CounterScript::new());
+
+    let mut reg = ScriptRegistry::new();
+    reg.attach(id, script);
+
+    reg.run_update(&mut world, 0.016);
+    reg.run_update(&mut world, 0.016);
+    reg.run_update(&mut world, 0.016);
+
+    // Retrieve via detach to inspect state
+    let mut reg2 = ScriptRegistry::new();
+    std::mem::swap(&mut reg, &mut reg2);
+    // We can't directly inspect inner box; use a shared-state approach instead.
+    // This test re-creates and asserts via separate cell.
+    drop(reg2);
+}
+
+#[test]
+fn on_start_called_once_verified_with_cell() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    let (mut world, id) = make_world_with_object();
+
+    let start_calls = Rc::new(Cell::new(0usize));
+    let sc = Rc::clone(&start_calls);
+
+    struct TrackStart(Rc<Cell<usize>>);
+    impl ObjectScript for TrackStart {
+        fn on_start(&mut self, _id: usize, _w: &mut World) {
+            self.0.set(self.0.get() + 1);
+        }
+    }
+
+    let mut reg = ScriptRegistry::new();
+    reg.attach(id, Box::new(TrackStart(sc)));
+
+    for _ in 0..5 {
+        reg.run_update(&mut world, 0.016);
+    }
+
+    assert_eq!(start_calls.get(), 1, "on_start must fire exactly once");
+}
+
+#[test]
+fn replacing_script_resets_on_start() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    let (mut world, id) = make_world_with_object();
+
+    let calls = Rc::new(Cell::new(0usize));
+
+    struct TrackStart(Rc<Cell<usize>>);
+    impl ObjectScript for TrackStart {
+        fn on_start(&mut self, _id: usize, _w: &mut World) {
+            self.0.set(self.0.get() + 1);
+        }
+    }
+
+    let mut reg = ScriptRegistry::new();
+    reg.attach(id, Box::new(TrackStart(Rc::clone(&calls))));
+    reg.run_update(&mut world, 0.016); // on_start fires once
+
+    // Replace the script
+    reg.attach(id, Box::new(TrackStart(Rc::clone(&calls))));
+    reg.run_update(&mut world, 0.016); // on_start fires again for the new script
+
+    assert_eq!(calls.get(), 2, "on_start should fire once per script instance");
+}
+
+#[test]
+fn on_update_receives_correct_id_and_dt() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    let (mut world, id) = make_world_with_object();
+
+    let seen_id = Rc::new(Cell::new(usize::MAX));
+    let seen_dt = Rc::new(Cell::new(0.0f32));
+    let si = Rc::clone(&seen_id);
+    let sd = Rc::clone(&seen_dt);
+
+    struct Tracker(Rc<Cell<usize>>, Rc<Cell<f32>>);
+    impl ObjectScript for Tracker {
+        fn on_update(&mut self, id: usize, _w: &mut World, dt: f32) {
+            self.0.set(id);
+            self.1.set(dt);
+        }
+    }
+
+    let mut reg = ScriptRegistry::new();
+    reg.attach(id, Box::new(Tracker(si, sd)));
+    reg.run_update(&mut world, 0.025);
+
+    assert_eq!(seen_id.get(), id);
+    assert!((seen_dt.get() - 0.025).abs() < 1e-6);
+}
+
+#[test]
+fn on_fixed_update_receives_correct_id_and_dt() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    let (mut world, id) = make_world_with_object();
+
+    let seen_id = Rc::new(Cell::new(usize::MAX));
+    let seen_dt = Rc::new(Cell::new(0.0f32));
+    let si = Rc::clone(&seen_id);
+    let sd = Rc::clone(&seen_dt);
+
+    struct Tracker(Rc<Cell<usize>>, Rc<Cell<f32>>);
+    impl ObjectScript for Tracker {
+        fn on_fixed_update(&mut self, id: usize, _w: &mut World, dt: f32) {
+            self.0.set(id);
+            self.1.set(dt);
+        }
+    }
+
+    let mut reg = ScriptRegistry::new();
+    reg.attach(id, Box::new(Tracker(si, sd)));
+    reg.run_fixed_update(&mut world, 0.0166);
+
+    assert_eq!(seen_id.get(), id);
+    assert!((seen_dt.get() - 0.0166).abs() < 1e-5);
+}
+
+#[test]
+fn script_can_mutate_world() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    let (mut world, id) = make_world_with_object();
+
+    let mutated = Rc::new(Cell::new(false));
+    let m = Rc::clone(&mutated);
+
+    struct Mutator(Rc<Cell<bool>>);
+    impl ObjectScript for Mutator {
+        fn on_update(&mut self, id: usize, world: &mut World, _dt: f32) {
+            if let Some(obj) = world.get_mut(id) {
+                obj.name = "mutated".into();
+                self.0.set(true);
+            }
+        }
+    }
+
+    let mut reg = ScriptRegistry::new();
+    reg.attach(id, Box::new(Mutator(m)));
+    reg.run_update(&mut world, 0.016);
+
+    assert!(mutated.get());
+    assert_eq!(world.objects[&id].name, "mutated");
+}
+
+#[test]
+fn multiple_scripts_all_run() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    let mut world = World::new();
+    let id_a = world.spawn_object(Object { name: "a".into(), str_id: "a".into(), ..Default::default() }, None);
+    let id_b = world.spawn_object(Object { name: "b".into(), str_id: "b".into(), ..Default::default() }, None);
+
+    let calls = Rc::new(Cell::new(0usize));
+
+    struct Inc(Rc<Cell<usize>>);
+    impl ObjectScript for Inc {
+        fn on_update(&mut self, _id: usize, _w: &mut World, _dt: f32) {
+            self.0.set(self.0.get() + 1);
+        }
+    }
+
+    let mut reg = ScriptRegistry::new();
+    reg.attach(id_a, Box::new(Inc(Rc::clone(&calls))));
+    reg.attach(id_b, Box::new(Inc(Rc::clone(&calls))));
+    reg.run_update(&mut world, 0.016);
+
+    assert_eq!(calls.get(), 2);
+}
+
+#[test]
+fn empty_registry_run_is_no_op() {
+    let (mut world, _id) = make_world_with_object();
+    let mut reg = ScriptRegistry::new();
+    // Must not panic
+    reg.run_update(&mut world, 0.016);
+    reg.run_fixed_update(&mut world, 0.016);
+}
+
+#[test]
+fn detach_middle_element_preserves_remaining() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    let mut world = World::new();
+    let ids: Vec<usize> = (0..3).map(|i| {
+        let s = i.to_string();
+        world.spawn_object(Object { name: s.clone(), str_id: s, ..Default::default() }, None)
+    }).collect();
+
+    let runs = Rc::new(Cell::new(0usize));
+    struct Inc(Rc<Cell<usize>>);
+    impl ObjectScript for Inc {
+        fn on_update(&mut self, _id: usize, _w: &mut World, _dt: f32) {
+            self.0.set(self.0.get() + 1);
+        }
+    }
+
+    let mut reg = ScriptRegistry::new();
+    for &id in &ids {
+        reg.attach(id, Box::new(Inc(Rc::clone(&runs))));
+    }
+
+    // Remove the middle entry
+    assert!(reg.detach(ids[1]));
+    assert_eq!(reg.len(), 2);
+
+    reg.run_update(&mut world, 0.016);
+    assert_eq!(runs.get(), 2);
+}
+

--- a/src/tests/test_scripts.rs
+++ b/src/tests/test_scripts.rs
@@ -312,3 +312,229 @@ fn detach_middle_element_preserves_remaining() {
     assert_eq!(runs.get(), 2);
 }
 
+/// `reset_started` must cause every script's `on_start` to fire again on the
+/// very next `run_update`, simulating a play-mode restart after a world restore.
+#[test]
+fn reset_started_causes_on_start_to_rerun() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    let (mut world, id) = make_world_with_object();
+
+    let calls = Rc::new(Cell::new(0usize));
+    struct TrackStart2(Rc<Cell<usize>>);
+    impl ObjectScript for TrackStart2 {
+        fn on_start(&mut self, _id: usize, _w: &mut World) {
+            self.0.set(self.0.get() + 1);
+        }
+    }
+
+    let mut reg = ScriptRegistry::new();
+    reg.attach(id, Box::new(TrackStart2(Rc::clone(&calls))));
+
+    reg.run_update(&mut world, 0.016); // on_start fires: count == 1
+    reg.run_update(&mut world, 0.016); // already started: count still 1
+    assert_eq!(calls.get(), 1);
+
+    reg.reset_started();
+
+    reg.run_update(&mut world, 0.016); // on_start re-fires: count == 2
+    reg.run_update(&mut world, 0.016); // already started again: count still 2
+    assert_eq!(calls.get(), 2, "on_start should fire again after reset_started");
+}
+
+/// `reset_started` must reset ALL entries when multiple scripts are registered.
+#[test]
+fn reset_started_resets_all_scripts() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    let mut world = World::new();
+    let id_a = world.spawn_object(Object { name: "a".into(), str_id: "a".into(), ..Default::default() }, None);
+    let id_b = world.spawn_object(Object { name: "b".into(), str_id: "b".into(), ..Default::default() }, None);
+
+    let calls = Rc::new(Cell::new(0usize));
+    struct TrackStart3(Rc<Cell<usize>>);
+    impl ObjectScript for TrackStart3 {
+        fn on_start(&mut self, _id: usize, _w: &mut World) {
+            self.0.set(self.0.get() + 1);
+        }
+    }
+
+    let mut reg = ScriptRegistry::new();
+    reg.attach(id_a, Box::new(TrackStart3(Rc::clone(&calls))));
+    reg.attach(id_b, Box::new(TrackStart3(Rc::clone(&calls))));
+
+    reg.run_update(&mut world, 0.016); // both start: count == 2
+    assert_eq!(calls.get(), 2);
+
+    reg.reset_started();
+    reg.run_update(&mut world, 0.016); // both re-start: count == 4
+    assert_eq!(calls.get(), 4, "reset_started should reset every registered script");
+}
+
+/// A script whose object was deleted must be automatically removed from the
+/// registry during the next `run_update` call (lazy pruning).
+#[test]
+fn stale_entry_pruned_on_run_update() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    let mut world = World::new();
+    let id_live = world.spawn_object(Object { name: "live".into(), str_id: "live".into(), ..Default::default() }, None);
+    let id_dead = world.spawn_object(Object { name: "dead".into(), str_id: "dead".into(), ..Default::default() }, None);
+
+    let update_calls = Rc::new(Cell::new(0usize));
+    struct Counter2(Rc<Cell<usize>>);
+    impl ObjectScript for Counter2 {
+        fn on_update(&mut self, _id: usize, _w: &mut World, _dt: f32) {
+            self.0.set(self.0.get() + 1);
+        }
+    }
+
+    let mut reg = ScriptRegistry::new();
+    reg.attach(id_live, Box::new(Counter2(Rc::clone(&update_calls))));
+    reg.attach(id_dead, Box::new(Counter2(Rc::clone(&update_calls))));
+    assert_eq!(reg.len(), 2);
+
+    world.delete(id_dead);
+
+    reg.run_update(&mut world, 0.016);
+
+    assert_eq!(reg.len(), 1, "stale entry must be pruned during run_update");
+    assert!(!reg.has(id_dead), "dead object's script must be gone");
+    assert!(reg.has(id_live), "live object's script must remain");
+    assert_eq!(update_calls.get(), 1, "only the live script should have run");
+}
+
+/// Stale entries are also pruned during `run_fixed_update`.
+#[test]
+fn stale_entry_pruned_on_run_fixed_update() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    let mut world = World::new();
+    let id_live = world.spawn_object(Object { name: "live".into(), str_id: "live".into(), ..Default::default() }, None);
+    let id_dead = world.spawn_object(Object { name: "dead".into(), str_id: "dead".into(), ..Default::default() }, None);
+
+    let fixed_calls = Rc::new(Cell::new(0usize));
+    struct Counter3(Rc<Cell<usize>>);
+    impl ObjectScript for Counter3 {
+        fn on_fixed_update(&mut self, _id: usize, _w: &mut World, _dt: f32) {
+            self.0.set(self.0.get() + 1);
+        }
+    }
+
+    let mut reg = ScriptRegistry::new();
+    reg.attach(id_live, Box::new(Counter3(Rc::clone(&fixed_calls))));
+    reg.attach(id_dead, Box::new(Counter3(Rc::clone(&fixed_calls))));
+
+    world.delete(id_dead);
+    reg.run_fixed_update(&mut world, 0.0166);
+
+    assert_eq!(reg.len(), 1);
+    assert!(!reg.has(id_dead));
+    assert!(reg.has(id_live));
+    assert_eq!(fixed_calls.get(), 1);
+}
+
+/// After all objects are deleted the registry must be completely empty and
+/// subsequent `detach` calls must not underflow (`len() - 1` on empty `Vec`).
+#[test]
+fn detach_after_all_objects_deleted_no_underflow() {
+    let mut world = World::new();
+    let id = world.spawn_object(Object { name: "x".into(), str_id: "x".into(), ..Default::default() }, None);
+
+    let mut reg = ScriptRegistry::new();
+    reg.attach(id, Box::new(CounterScript::new()));
+
+    world.delete(id);
+    reg.run_update(&mut world, 0.016); // prunes the stale entry
+
+    assert!(reg.is_empty());
+    assert!(!reg.detach(id));
+}
+
+/// Pruning consecutive stale entries must not skip the element that
+/// was swapped into the pruned slot.
+#[test]
+fn multiple_stale_entries_all_pruned() {
+    let mut world = World::new();
+    let ids: Vec<usize> = (0..4)
+        .map(|i| {
+            let s = format!("obj{i}");
+            world.spawn_object(Object { name: s.clone(), str_id: s, ..Default::default() }, None)
+        })
+        .collect();
+
+    let mut reg = ScriptRegistry::new();
+    for &id in &ids {
+        reg.attach(id, Box::new(CounterScript::new()));
+    }
+
+    for &id in &ids[..3] {
+        world.delete(id);
+    }
+
+    reg.run_update(&mut world, 0.016);
+
+    assert_eq!(reg.len(), 1, "only the surviving object's script must remain");
+    assert!(reg.has(ids[3]));
+}
+
+/// Run update twice in a row to confirm entries are not accidentally consumed.
+#[test]
+fn run_update_twice_without_consuming_entries() {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    let (mut world, id) = make_world_with_object();
+
+    let calls = Rc::new(Cell::new(0usize));
+    struct Counter4(Rc<Cell<usize>>);
+    impl ObjectScript for Counter4 {
+        fn on_update(&mut self, _id: usize, _w: &mut World, _dt: f32) {
+            self.0.set(self.0.get() + 1);
+        }
+    }
+
+    let mut reg = ScriptRegistry::new();
+    reg.attach(id, Box::new(Counter4(Rc::clone(&calls))));
+
+    reg.run_update(&mut world, 0.016);
+    reg.run_update(&mut world, 0.016);
+
+    assert_eq!(reg.len(), 1, "entries must still be present after two run_update calls");
+    assert_eq!(calls.get(), 2);
+}
+
+/// `has`, `detach`, and `len` must all remain correct after several
+/// `run_update` calls (index consistency check).
+#[test]
+fn index_consistent_across_multiple_run_update_calls() {
+    let mut world = World::new();
+    let ids: Vec<usize> = (0..3)
+        .map(|i| {
+            let s = format!("o{i}");
+            world.spawn_object(Object { name: s.clone(), str_id: s, ..Default::default() }, None)
+        })
+        .collect();
+
+    let mut reg = ScriptRegistry::new();
+    for &id in &ids {
+        reg.attach(id, Box::new(CounterScript::new()));
+    }
+
+    for _ in 0..5 {
+        reg.run_update(&mut world, 0.016);
+    }
+
+    assert_eq!(reg.len(), 3);
+    for &id in &ids {
+        assert!(reg.has(id));
+    }
+
+    assert!(reg.detach(ids[1]));
+    assert_eq!(reg.len(), 2);
+    assert!(!reg.has(ids[1]));
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -279,6 +279,7 @@ impl<S> Window<S> {
             editor: None,
             textures: std::collections::HashMap::new(),
             snapshot: None,
+            script_registry: crate::script::ScriptRegistry::new(),
         });
         if let Some(startup_fn) = &mut self.on_startup_fn {
             startup_fn(&mut self.state, &mut *scene, &mut FrameContext { dt: 0.0 });
@@ -290,6 +291,7 @@ impl<S> Window<S> {
             last_update_inst = now;
 
             if scene.editor.is_none() {
+                scene.run_scripts(dt);
                 if let Some(f) = &mut self.on_update_fn {
                     f(&mut self.state, &mut *scene, &mut FrameContext { dt });
                 }
@@ -357,6 +359,7 @@ impl<S> Window<S> {
                     accumulator += dt;
                     while accumulator >= window::FIXED_DELTA {
                         if scene.editor.is_none() {
+                            scene.run_fixed_update_scripts(window::FIXED_DELTA);
                             if let Some(f) = &mut self.on_fixed_update_fn {
                                 f(&mut self.state, &mut *scene, &mut FrameContext { dt: window::FIXED_DELTA });
                             }


### PR DESCRIPTION
This pull request introduces a per-object scripting system to the engine, allowing scripts to be attached to individual scene objects. Scripts support `on_start`, `on_update`, and `on_fixed_update` callbacks, and can be authored in both Rust and JavaScript (via WASM). The PR also includes a comprehensive example demonstrating various script types.

**Per-object scripting system:**

* Added a new `script` module and `ScriptRegistry`, and integrated them into the `Scene` struct for managing per-object scripts without affecting serialization. (`src/lib.rs`, `src/scene.rs`, `binder/src/lib.rs`, `binder/src/scene.rs`) [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R37) [[2]](diffhunk://#diff-60e84ff1e59fc5d81afd0bdb05ef7c9ffa04c643044ee348d41eadab8a29bf58R10) [[3]](diffhunk://#diff-60e84ff1e59fc5d81afd0bdb05ef7c9ffa04c643044ee348d41eadab8a29bf58R55-R57) [[4]](diffhunk://#diff-665e9b5a1981f4b9e3b96d14c1ce60058d61860da3ce770e11d0f6c69cda5ed2R9) [[5]](diffhunk://#diff-0f8f267ff9a6b582fec56f3acbbb9ef118d96e32da97ab2e47f09e119d2faf59R8)

* Implemented public methods on `Scene` for script management: `attach_script`, `detach_script`, `has_script`, `run_scripts`, and `run_fixed_update_scripts`. These methods allow attaching, detaching, checking, and running scripts on objects. (`src/scene.rs`, `binder/src/scene.rs`) [[1]](diffhunk://#diff-60e84ff1e59fc5d81afd0bdb05ef7c9ffa04c643044ee348d41eadab8a29bf58R251-R291) [[2]](diffhunk://#diff-0f8f267ff9a6b582fec56f3acbbb9ef118d96e32da97ab2e47f09e119d2faf59R220-R246)

**JavaScript/WASM scripting support:**

* Added `binder/src/script.rs` with `JsObjectScript` and `WasmScript` types, enabling JavaScript scripts to be attached to objects. JS scripts can define `on_start`, `on_update`, and `on_fixed_update` callbacks, and are interoperable via WASM bindings. (`binder/src/script.rs`)

**Example and documentation:**

* Added `examples/scripted_objects.rs`, demonstrating the new scripting system with several objects each using a different script (e.g., rotation, bobbing, color cycling, logging). The example covers both the API and practical usage. (`examples/scripted_objects.rs`)