### PR TITLE
Fix triangle and quad vertex order in geometry calculations

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -134,12 +134,12 @@ impl Geometry {
                 let b4 = [-s, -h, -s]; // Back-Left
 
                 // 4 Sides
-                mesh_data.add_transformed_triangle([tip, b1, b2], transform, color); // Front
-                mesh_data.add_transformed_triangle([tip, b2, b3], transform, color); // Right
-                mesh_data.add_transformed_triangle([tip, b3, b4], transform, color); // Back
-                mesh_data.add_transformed_triangle([tip, b4, b1], transform, color); // Left
+                mesh_data.add_transformed_triangle([tip, b2, b1], transform, color); // Front
+                mesh_data.add_transformed_triangle([tip, b3, b2], transform, color); // Right
+                mesh_data.add_transformed_triangle([tip, b4, b3], transform, color); // Back
+                mesh_data.add_transformed_triangle([tip, b1, b4], transform, color); // Left
                 // Base
-                mesh_data.add_transformed_quad([b4, b3, b2, b1], transform, color);
+                mesh_data.add_transformed_quad([b1, b2, b3, b4], transform, color);
             }
             Geometry::Capsule { radius, height, subdivisions } => {
                 let r = *radius;


### PR DESCRIPTION
This pull request updates the winding order of triangles and the vertex order of the quad when generating a pyramid mesh in the `Geometry` implementation. These changes ensure that the faces are defined with a consistent and correct winding, which is important for proper rendering (e.g., backface culling and normal direction).

Mesh generation fixes:

* Corrected the vertex order for the four pyramid side triangles in the `Geometry::Pyramid` mesh generation to ensure consistent winding.
* Adjusted the base quad's vertex order for the pyramid to match the new winding convention.